### PR TITLE
Optimize Prisma production builds and refine configuration

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,71 +2,71 @@ import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 import createMDX from "@next/mdx";
 
+const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
+const withMDX = createMDX({
+  extension: /\.mdx?$/,
+});
+
+const baseNextConfig: NextConfig = {
+  pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
+  reactCompiler: true,
+  // Configure webpack for raw imports
+  webpack: (config) => {
+    config.module.rules.push({
+      resourceQuery: /raw/,
+      type: 'asset/source',
+    });
+    return config;
+  },
+  // Enable standalone output for Docker
+  output: "standalone",
+  // Experimental features
+  experimental: {
+    // Enable server actions
+    serverActions: {
+      bodySizeLimit: "2mb",
+    },
+  },
+  // Image optimization
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**",
+      },
+    ],
+  },
+  // Redirects
+  async redirects() {
+    return [
+      {
+        source: "/vibe",
+        destination: "/categories/vibe",
+        permanent: true,
+      },
+      {
+        source: "/sponsors",
+        destination: "/categories/sponsors",
+        permanent: true,
+      },
+      {
+        source: "/embed-preview",
+        destination: "/embed",
+        permanent: true,
+      },
+    ];
+  },
+};
+
+const configWithPlugins = withMDX(withNextIntl(baseNextConfig));
+
 let finalConfig: NextConfig;
 
 try {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { withSentryConfig } = require("@sentry/nextjs");
 
-  const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
-  const withMDX = createMDX({
-    extension: /\.mdx?$/,
-  });
-
-  const nextConfig: NextConfig = {
-    pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
-    reactCompiler: true,
-    // Configure webpack for raw imports
-    webpack: (config) => {
-      config.module.rules.push({
-        resourceQuery: /raw/,
-        type: 'asset/source',
-      });
-      return config;
-    },
-    // Enable standalone output for Docker
-    output: "standalone",
-    // Experimental features
-    experimental: {
-      // Enable server actions
-      serverActions: {
-        bodySizeLimit: "2mb",
-      },
-    },
-    // Image optimization
-    images: {
-      remotePatterns: [
-        {
-          protocol: "https",
-          hostname: "**",
-        },
-      ],
-    },
-    // Redirects
-    async redirects() {
-      return [
-        {
-          source: "/vibe",
-          destination: "/categories/vibe",
-          permanent: true,
-        },
-        {
-          source: "/sponsors",
-          destination: "/categories/sponsors",
-          permanent: true,
-        },
-        {
-          source: "/embed-preview",
-          destination: "/embed",
-          permanent: true,
-        },
-      ];
-    },
-  };
-
-  const baseConfig = withMDX(withNextIntl(nextConfig));
-
-  finalConfig = withSentryConfig(baseConfig, {
+  finalConfig = withSentryConfig(configWithPlugins, {
     org: "promptschat",
     project: "prompts-chat",
     silent: !process.env.CI,
@@ -80,64 +80,8 @@ try {
     },
   });
 } catch {
-  // Sentry not available, use base config
-  const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
-  const withMDX = createMDX({
-    extension: /\.mdx?$/,
-  });
-
-  const nextConfig: NextConfig = {
-    pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
-    reactCompiler: true,
-    // Configure webpack for raw imports
-    webpack: (config) => {
-      config.module.rules.push({
-        resourceQuery: /raw/,
-        type: 'asset/source',
-      });
-      return config;
-    },
-    // Enable standalone output for Docker
-    output: "standalone",
-    // Experimental features
-    experimental: {
-      // Enable server actions
-      serverActions: {
-        bodySizeLimit: "2mb",
-      },
-    },
-    // Image optimization
-    images: {
-      remotePatterns: [
-        {
-          protocol: "https",
-          hostname: "**",
-        },
-      ],
-    },
-    // Redirects
-    async redirects() {
-      return [
-        {
-          source: "/vibe",
-          destination: "/categories/vibe",
-          permanent: true,
-        },
-        {
-          source: "/sponsors",
-          destination: "/categories/sponsors",
-          permanent: true,
-        },
-        {
-          source: "/embed-preview",
-          destination: "/embed",
-          permanent: true,
-        },
-      ];
-    },
-  };
-
-  finalConfig = withMDX(withNextIntl(nextConfig));
+  // Sentry not available, use config without Sentry
+  finalConfig = configWithPlugins;
 }
 
 export default finalConfig;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && bun exec next build",
+    "build": "prisma generate --no-engine && bun exec next build",
     "db:deploy": "prisma migrate deploy",
     "start": "next start",
     "lint": "eslint",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "db:setup": "prisma generate && prisma migrate dev && prisma db seed",
     "setup": "node scripts/setup.js",
     "generate:examples": "npx tsx scripts/generate-examples.ts",
-    "postinstall": "prisma generate",
+    "postinstall": "prisma generate --no-engine",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   engine: "classic",
+  generate: {
+    skipEngine: process.env.NODE_ENV === "production",
+  },
   datasource: {
     url: process.env.DATABASE_URL ?? "postgresql://placeholder:placeholder@localhost:5432/placeholder",
   },


### PR DESCRIPTION
- Configured Prisma generation to use the `--no-engine` flag in production to reduce build size and optimize output.
- Updated postinstall scripts to skip unnecessary engine bundling during the build process.
- Refactored `next.config.js` to prevent duplicate declarations of `withNextIntl` and `withMDX` by moving them outside of try-catch blocks.

[v0 Session](https://v0.app/chat/iOxM7hTEEP3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored Next.js configuration assembly to reduce redundant operations during the build process
  * Updated Prisma client generation settings to skip unnecessary engine components in production builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->