### PR TITLE
🎨 Palette: Add aria-label to notification bell

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Dynamically updating `aria-label` inside of the notification badge count
+**Learning:** When applying `aria-label` to buttons that contain dynamically updated visual content (e.g., a notification badge count), the `aria-label` completely overrides the inner content for screen readers. It is important to construct a comprehensive `aria-label` combining both the title and the dynamic value, and hide the visible dynamic content using `aria-hidden="true"`.
+**Action:** When creating notification buttons with dynamic counters or similar visual counters, provide an `aria-label` like "Notifications (2)" and add `aria-hidden="true"` to the icon and badge elements inside.

--- a/src/components/layout/notification-bell.tsx
+++ b/src/components/layout/notification-bell.tsx
@@ -98,8 +98,8 @@ export function NotificationBell() {
   if (totalCount === 0) {
     return (
       <Button variant="ghost" size="icon" className="h-8 w-8 relative" asChild>
-        <Link href={`/@${session.user.username}`}>
-          <Bell className="h-4 w-4" />
+        <Link href={`/@${session.user.username}`} aria-label={t("title")}>
+          <Bell className="h-4 w-4" aria-hidden="true" />
         </Link>
       </Button>
     );
@@ -108,9 +108,9 @@ export function NotificationBell() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="h-8 w-8 relative">
-          <Bell className="h-4 w-4" />
-          <span className="absolute -top-0.5 -right-0.5 h-4 w-4 rounded-full bg-red-500 text-white text-[10px] font-medium flex items-center justify-center">
+        <Button variant="ghost" size="icon" className="h-8 w-8 relative" aria-label={`${t("title")} (${totalCount})`}>
+          <Bell className="h-4 w-4" aria-hidden="true" />
+          <span className="absolute -top-0.5 -right-0.5 h-4 w-4 rounded-full bg-red-500 text-white text-[10px] font-medium flex items-center justify-center" aria-hidden="true">
             {totalCount > 9 ? "9+" : totalCount}
           </span>
         </Button>


### PR DESCRIPTION
💡 What: Added dynamic `aria-label`s to the `NotificationBell` component based on whether the user has unread notifications, and added `aria-hidden="true"` to visual-only elements (the Bell icon and the badge counter).
🎯 Why: Without these labels, screen reader users interact with the bell and hear only "Button" and missing context about the unread notifications count since the inner elements are visually structured.
📸 Before/After: Visuals haven't changed, but structural HTML now includes `aria-label="Notifications"` (empty state) and `aria-label="Notifications (2)"` (unread state), with appropriate `aria-hidden="true"`.
♿ Accessibility: Ensures that dynamic button badges correctly announce their value to screen reader users instead of just relying on inner text that gets overridden.

---
*PR created automatically by Jules for task [1837868760056141229](https://jules.google.com/task/1837868760056141229) started by @billlzzz10*