### PR TITLE
🧹 cleanup unused imports in prompt-form.tsx

### DIFF
--- a/src/components/prompts/prompt-form.tsx
+++ b/src/components/prompts/prompt-form.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from "next-intl";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { Loader2, Upload, X, ArrowDown, Play, Image as ImageIcon, Video, Volume2, Paperclip, Search, Sparkles, BookOpen, ExternalLink, ChevronDown, Settings2 } from "lucide-react";
+import { Loader2, Upload, X, ArrowDown, Image as ImageIcon, Video, Volume2, Paperclip, Search, Sparkles, BookOpen, ExternalLink, ChevronDown, Settings2 } from "lucide-react";
 import Link from "next/link";
 import { VariableToolbar } from "./variable-toolbar";
 import { VariableWarning } from "./variable-warning";
@@ -21,22 +21,13 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
 import {
-  parseSkillFiles,
-  serializeSkillFiles,
-  getLanguageFromFilename,
-  validateFilename,
-  suggestFilename,
   generateSkillContentWithFrontmatter,
   updateSkillFrontmatter,
   validateSkillFrontmatter,
-  DEFAULT_SKILL_FILE,
-  DEFAULT_SKILL_CONTENT,
-  type SkillFile,
 } from "@/lib/skill-files";
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
- Removed unused `FormDescription` import from `@/components/ui/form`.
- Removed unused `Play` icon import from `lucide-react`.
- Removed several unused utility functions and types from `@/lib/skill-files`.

💡 **Why:** How this improves maintainability
- Reduces clutter in the import block.
- Improves code clarity by ensuring only used symbols are imported.
- Potentially reduces bundle size (though likely negligible for these specific imports, it's good practice).

✅ **Verification:** How you confirmed the change is safe
- Used `grep` and `read_file` to confirm that the removed symbols were indeed not used anywhere else in the file.
- Changes were manually reviewed and approved.

✨ **Result:** The improvement achieved
- A cleaner, more maintainable `src/components/prompts/prompt-form.tsx` file.

---
*PR created automatically by Jules for task [663788150734092787](https://jules.google.com/task/663788150734092787) started by @billlzzz10*