### PR TITLE
🧹 improve types in Auth Callbacks and Adapter

### DIFF
--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -1,4 +1,6 @@
 import NextAuth from "next-auth";
+import type { Session as AuthSession, User as AuthUser } from "next-auth";
+import type { JWT as AuthJWT } from "next-auth/jwt";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { db } from "@/lib/db";
 import { getConfig } from "@/lib/config";
@@ -43,10 +45,8 @@ function CustomPrismaAdapter(): Adapter {
     ...prismaAdapter,
     async createUser(data: AdapterUser & { username?: string; githubUsername?: string }) {
       // Use GitHub username if provided, otherwise generate one
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let username = (data as any).username;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const githubUsername = (data as any).githubUsername; // Immutable GitHub username
+      let username = data.username;
+      const githubUsername = data.githubUsername; // Immutable GitHub username
       
       if (!username) {
         username = await generateUsername(data.email, data.name);
@@ -154,8 +154,7 @@ async function buildAuthConfig() {
       error: "/login",
     },
     callbacks: {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      async jwt({ token, user, trigger }: { token: any; user?: any; trigger?: string }) {
+      async jwt({ token, user, trigger }: { token: AuthJWT; user?: AuthUser; trigger?: string }) {
         // On sign in, look up the actual database user by email to ensure correct ID
         if (user && user.email) {
           const dbUser = await db.user.findUnique({
@@ -197,8 +196,7 @@ async function buildAuthConfig() {
 
         return token;
       },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      async session({ session, token }: { session: any; token: any }) {
+      async session({ session, token }: { session: AuthSession; token: AuthJWT }) {
         // If token is null/invalid, return empty session
         if (!token) {
           return { ...session, user: undefined };


### PR DESCRIPTION
This change improves the maintainability and type safety of the authentication logic in `src/lib/auth/index.ts`. 

Key improvements:
1. **Stronger Typing in Callbacks:** The `jwt` and `session` callbacks now use `AuthJWT`, `AuthUser`, and `AuthSession` types instead of `any`. These types are aliased from `next-auth` and `next-auth/jwt` to prevent conflicts with the local Prisma `User` model while still benefiting from the module augmentation defined at the bottom of the file.
2. **Cleaned up Adapter logic:** Removed unnecessary `any` casts and ESLint disable comments in the `createUser` method of `CustomPrismaAdapter`, as the `data` parameter's type already correctly included the `username` and `githubUsername` fields.
3. **Better Readability:** Removing `any` and `eslint-disable` comments makes the code cleaner and more standard-compliant.

Verification:
- Manually reviewed the code to ensure correct property access on typed objects.
- Verified that all `any` usages and related ESLint bypasses in the targeted areas were removed.
- Ensured type aliasing prevents regressions in existing logic that depends on the Prisma `User` type.

---
*PR created automatically by Jules for task [6930264853606380424](https://jules.google.com/task/6930264853606380424) started by @billlzzz10*