### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/src/components/comments/comment-item.tsx
+++ b/src/components/comments/comment-item.tsx
@@ -266,8 +266,9 @@ export function CommentItem({
                 localUserVote === 1 && "text-primary"
               )}
               title={t("upvote")}
+              aria-label={t("upvote")}
             >
-              <ChevronUp className="h-4 w-4" />
+              <ChevronUp className="h-4 w-4" aria-hidden="true" />
             </button>
             <span
               className={cn(
@@ -286,8 +287,9 @@ export function CommentItem({
                 localUserVote === -1 && "text-destructive"
               )}
               title={t("downvote")}
+              aria-label={t("downvote")}
             >
-              <ChevronDown className="h-4 w-4" />
+              <ChevronDown className="h-4 w-4" aria-hidden="true" />
             </button>
           </div>
 

--- a/src/components/layout/cli-command.tsx
+++ b/src/components/layout/cli-command.tsx
@@ -55,8 +55,10 @@ export function CliCommand() {
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
         className="group inline-flex cursor-pointer items-center gap-3 rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2.5 transition-all duration-300 hover:bg-zinc-800 dark:border-zinc-600 dark:bg-zinc-800 dark:hover:bg-zinc-700"
+        aria-label={tCommon("copy")}
+        title={tCommon("copy")}
       >
-        <Terminal className="h-4 w-4 shrink-0 text-green-400" />
+        <Terminal className="h-4 w-4 shrink-0 text-green-400" aria-hidden="true" />
         <div className="relative flex h-5 items-center overflow-hidden">
           {/* Grid container for smooth width animation */}
           <div

--- a/src/components/prompts/widget-card.tsx
+++ b/src/components/prompts/widget-card.tsx
@@ -133,8 +133,13 @@ export function WidgetCard({ prompt }: WidgetCardProps) {
           )}
         </div>
         <div className="flex items-center gap-2">
-          <button onClick={copyToClipboard} className="hover:bg-accent rounded p-1">
-            <Copy className="h-3 w-3" />
+          <button
+            onClick={copyToClipboard}
+            className="hover:bg-accent rounded p-1"
+            aria-label={tCommon("copy")}
+            title={tCommon("copy")}
+          >
+            <Copy className="h-3 w-3" aria-hidden="true" />
           </button>
           {prompt.actionUrl ? (
             <Link


### PR DESCRIPTION
💡 What: Added `aria-label`, `title`, and `aria-hidden="true"` to icon-only buttons in `CommentItem`, `CliCommand`, and `WidgetCard` components.
🎯 Why: To improve accessibility for screen readers and usability for mouse users by explicitly labeling decorative icons and adding native tooltips.
♿ Accessibility: Explicitly hides decorative SVGs with `aria-hidden` and provides accurate descriptive text using `aria-label` which improves screen reader comprehension.

---
*PR created automatically by Jules for task [14143833118671211364](https://jules.google.com/task/14143833118671211364) started by @billlzzz10*