### PR TITLE
🎨 Palette: hide decorative icons from screen readers in Sidebar

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ prisma/generated
 package-lock.json
 *.min.js
 *.min.css
+pnpm-lock.yaml

--- a/src/__tests__/api/search.test.ts
+++ b/src/__tests__/api/search.test.ts
@@ -154,7 +154,9 @@ describe("GET /api/prompts/search", () => {
     vi.mocked(auth).mockResolvedValue({ user: { id: "user1" } } as never);
     vi.mocked(db.prompt.findMany).mockResolvedValue([]);
 
-    const request = new NextRequest("http://localhost:3000/api/prompts/search?q=test&ownerOnly=true");
+    const request = new NextRequest(
+      "http://localhost:3000/api/prompts/search?q=test&ownerOnly=true"
+    );
 
     await GET(request);
 

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -46,7 +46,7 @@ export function Sidebar() {
       {/* Logo / Brand */}
       <div className="mb-8">
         <div className="flex h-8 w-8 items-center justify-center rounded-sm border border-white/20 bg-white/10">
-          <Terminal size={16} className="text-agent-cyan" />
+          <Terminal size={16} className="text-agent-cyan" aria-hidden="true" />
         </div>
       </div>
 
@@ -66,7 +66,7 @@ export function Sidebar() {
                   : "text-white/40 hover:bg-white/5 hover:text-white"
               )}
             >
-              <item.icon size={20} />
+              <item.icon size={20} aria-hidden="true" />
               {/* Tooltip on Hover */}
               <span className="pointer-events-none absolute left-14 z-50 rounded border border-white/10 bg-black/80 px-2 py-1 text-xs whitespace-nowrap opacity-0 backdrop-blur-md transition-opacity group-hover:opacity-100">
                 {item.label}
@@ -83,7 +83,7 @@ export function Sidebar() {
           className="group relative mb-2 rounded-md p-3 text-white/40 transition-all hover:bg-white/5 hover:text-white"
           aria-label="Toggle Language"
         >
-          <Globe size={20} />
+          <Globe size={20} aria-hidden="true" />
           <span className="pointer-events-none absolute left-14 z-50 rounded border border-white/10 bg-black/80 px-2 py-1 font-mono text-[10px] whitespace-nowrap uppercase opacity-0 backdrop-blur-md transition-opacity group-hover:opacity-100">
             Toggle EN/TH
           </span>

--- a/src/components/prompts/prompt-card.tsx
+++ b/src/components/prompts/prompt-card.tsx
@@ -221,7 +221,7 @@ export function PromptCard({ prompt, showPinButton = false, isPinned = false }: 
           )}
           <div className="from-background via-background/30 pointer-events-none absolute inset-0 bg-gradient-to-t to-transparent" />
           {/* Badges overlay */}
-          <div className="absolute right-2 top-2 flex items-center gap-1.5">
+          <div className="absolute top-2 right-2 flex items-center gap-1.5">
             {isFlowStart && (
               <div className="bg-background/80 flex items-center gap-0.5 rounded px-1.5 py-0.5 backdrop-blur-sm">
                 <Link2 className="text-muted-foreground h-3 w-3" />
@@ -305,13 +305,13 @@ export function PromptCard({ prompt, showPinButton = false, isPinned = false }: 
             />
           ) : (
             <pre
-              className={`text-muted-foreground bg-muted h-full overflow-hidden whitespace-pre-wrap break-words rounded p-2 font-mono text-xs ${hasMediaBackground ? "line-clamp-2" : "line-clamp-4"}`}
+              className={`text-muted-foreground bg-muted h-full overflow-hidden rounded p-2 font-mono text-xs break-words whitespace-pre-wrap ${hasMediaBackground ? "line-clamp-2" : "line-clamp-4"}`}
             >
               {contentHasVariables ? renderContentWithVariables(prompt.content) : prompt.content}
             </pre>
           )}
           {showPinButton && (
-            <div className="absolute right-1.5 top-1.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+            <div className="absolute top-1.5 right-1.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
               <PinButton promptId={prompt.id} initialPinned={isPinned} iconOnly />
             </div>
           )}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -20,7 +20,7 @@ interface RequestErrorMetadata {
 export const onRequestError = async (
   error: Error,
   request: RequestErrorMetadata,
-  _context: unknown,
+  _context: unknown
 ) => {
   try {
     const Sentry = await import("@sentry/nextjs");

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -278,10 +278,7 @@ function replacePlaceholders(template: string, prompt: PromptData): string {
   return result;
 }
 
-export async function triggerWebhooks(
-  event: WebhookEvent,
-  prompt: PromptData
-): Promise<void> {
+export async function triggerWebhooks(event: WebhookEvent, prompt: PromptData): Promise<void> {
   try {
     // Get all enabled webhooks for this event
     const webhooks = await db.webhookConfig.findMany({


### PR DESCRIPTION
🎨 Palette: hide decorative icons from screen readers in Sidebar

- Added \`aria-hidden="true"\` to the \`Terminal\` brand icon.
- Added \`aria-hidden="true"\` to the dynamically rendered \`item.icon\` for navigation links, as the parent \`<Link>\` already has an explicit \`aria-label\`.
- Added \`aria-hidden="true"\` to the \`Globe\` icon inside the "Toggle Language" button, which also already has an explicit \`aria-label\`.

These changes prevent screen readers from redundantly announcing the icons, improving the clarity of the interface for assistive technology users.

---
*PR created automatically by Jules for task [6019073958685796425](https://jules.google.com/task/6019073958685796425) started by @billlzzz10*