### PR TITLE
🎨 Palette: Add ARIA labels and hide decorative icons in admin tables

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ prisma/generated
 package-lock.json
 *.min.js
 *.min.css
+pnpm-lock.yaml

--- a/messages/en.json
+++ b/messages/en.json
@@ -20,6 +20,8 @@
     "copiedToClipboard": "Copied to clipboard",
     "failedToCopy": "Failed to copy",
     "submit": "Submit",
+    "more": "More",
+    "openInNewTab": "Open in new tab",
     "back": "Back",
     "next": "Next",
     "previous": "Previous",

--- a/src/__tests__/api/search.test.ts
+++ b/src/__tests__/api/search.test.ts
@@ -154,7 +154,9 @@ describe("GET /api/prompts/search", () => {
     vi.mocked(auth).mockResolvedValue({ user: { id: "user1" } } as never);
     vi.mocked(db.prompt.findMany).mockResolvedValue([]);
 
-    const request = new NextRequest("http://localhost:3000/api/prompts/search?q=test&ownerOnly=true");
+    const request = new NextRequest(
+      "http://localhost:3000/api/prompts/search?q=test&ownerOnly=true"
+    );
 
     await GET(request);
 

--- a/src/components/admin/prompts-management.tsx
+++ b/src/components/admin/prompts-management.tsx
@@ -837,11 +837,13 @@ export function PromptsManagement({
                 variant="outline"
                 onClick={handleSearch}
                 disabled={loadingPrompts}
+                aria-label={tCommon("search")}
+                title={tCommon("search")}
               >
                 {loadingPrompts ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
                 ) : (
-                  <Search className="h-4 w-4" />
+                  <Search className="h-4 w-4" aria-hidden="true" />
                 )}
               </Button>
             </div>
@@ -896,8 +898,14 @@ export function PromptsManagement({
                   <div className="flex flex-shrink-0 items-center gap-2">
                     {prompt.id && (
                       <Link href={`/prompts/${prompt.id}`} target="_blank" prefetch={false}>
-                        <Button size="icon" variant="ghost" className="h-8 w-8">
-                          <ExternalLink className="h-4 w-4" />
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-8 w-8"
+                          aria-label={tCommon("openInNewTab")}
+                          title={tCommon("openInNewTab")}
+                        >
+                          <ExternalLink className="h-4 w-4" aria-hidden="true" />
                         </Button>
                       </Link>
                     )}
@@ -906,8 +914,10 @@ export function PromptsManagement({
                       variant="ghost"
                       className="text-destructive hover:text-destructive hover:bg-destructive/10 h-8 w-8"
                       onClick={() => setPromptToDelete(prompt)}
+                      aria-label={tCommon("delete")}
+                      title={tCommon("delete")}
                     >
-                      <Trash2 className="h-4 w-4" />
+                      <Trash2 className="h-4 w-4" aria-hidden="true" />
                     </Button>
                   </div>
                 </div>
@@ -961,8 +971,10 @@ export function PromptsManagement({
                 className="h-8 w-8"
                 disabled={currentPage === 1 || loadingPrompts}
                 onClick={() => setCurrentPage((p) => p - 1)}
+                aria-label={tCommon("previous")}
+                title={tCommon("previous")}
               >
-                <ChevronLeft className="h-4 w-4" />
+                <ChevronLeft className="h-4 w-4" aria-hidden="true" />
               </Button>
               <span className="px-2 text-sm tabular-nums">
                 {currentPage} / {pagination.totalPages}
@@ -973,8 +985,10 @@ export function PromptsManagement({
                 className="h-8 w-8"
                 disabled={currentPage === pagination.totalPages || loadingPrompts}
                 onClick={() => setCurrentPage((p) => p + 1)}
+                aria-label={tCommon("next")}
+                title={tCommon("next")}
               >
-                <ChevronRight className="h-4 w-4" />
+                <ChevronRight className="h-4 w-4" aria-hidden="true" />
               </Button>
             </div>
           </div>

--- a/src/components/admin/users-table.tsx
+++ b/src/components/admin/users-table.tsx
@@ -277,11 +277,18 @@ export function UsersTable() {
                 className="w-full pl-9 sm:w-[200px]"
               />
             </div>
-            <Button size="icon" variant="outline" onClick={handleSearch} disabled={loadingUsers}>
+            <Button
+              size="icon"
+              variant="outline"
+              onClick={handleSearch}
+              disabled={loadingUsers}
+              aria-label={tCommon("search")}
+              title={tCommon("search")}
+            >
               {loadingUsers ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
               ) : (
-                <Search className="h-4 w-4" />
+                <Search className="h-4 w-4" aria-hidden="true" />
               )}
             </Button>
           </div>
@@ -325,8 +332,14 @@ export function UsersTable() {
                   </div>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" size="icon" className="h-8 w-8 flex-shrink-0">
-                        <MoreHorizontal className="h-4 w-4" />
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 flex-shrink-0"
+                        aria-label={tCommon("more")}
+                        title={tCommon("more")}
+                      >
+                        <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
@@ -440,8 +453,14 @@ export function UsersTable() {
                     <TableCell>
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
-                          <Button variant="ghost" size="icon" className="h-8 w-8">
-                            <MoreHorizontal className="h-4 w-4" />
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                            aria-label={tCommon("more")}
+                            title={tCommon("more")}
+                          >
+                            <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
@@ -506,8 +525,10 @@ export function UsersTable() {
                   className="h-8 w-8"
                   disabled={currentPage === 1 || loadingUsers}
                   onClick={() => setCurrentPage((p) => p - 1)}
+                  aria-label={tCommon("previous")}
+                  title={tCommon("previous")}
                 >
-                  <ChevronLeft className="h-4 w-4" />
+                  <ChevronLeft className="h-4 w-4" aria-hidden="true" />
                 </Button>
                 <span className="px-2 text-sm tabular-nums">
                   {currentPage} / {pagination.totalPages}
@@ -518,8 +539,10 @@ export function UsersTable() {
                   className="h-8 w-8"
                   disabled={currentPage === pagination.totalPages || loadingUsers}
                   onClick={() => setCurrentPage((p) => p + 1)}
+                  aria-label={tCommon("next")}
+                  title={tCommon("next")}
                 >
-                  <ChevronRight className="h-4 w-4" />
+                  <ChevronRight className="h-4 w-4" aria-hidden="true" />
                 </Button>
               </div>
             </div>

--- a/src/components/prompts/prompt-card.tsx
+++ b/src/components/prompts/prompt-card.tsx
@@ -221,7 +221,7 @@ export function PromptCard({ prompt, showPinButton = false, isPinned = false }: 
           )}
           <div className="from-background via-background/30 pointer-events-none absolute inset-0 bg-gradient-to-t to-transparent" />
           {/* Badges overlay */}
-          <div className="absolute right-2 top-2 flex items-center gap-1.5">
+          <div className="absolute top-2 right-2 flex items-center gap-1.5">
             {isFlowStart && (
               <div className="bg-background/80 flex items-center gap-0.5 rounded px-1.5 py-0.5 backdrop-blur-sm">
                 <Link2 className="text-muted-foreground h-3 w-3" />
@@ -305,13 +305,13 @@ export function PromptCard({ prompt, showPinButton = false, isPinned = false }: 
             />
           ) : (
             <pre
-              className={`text-muted-foreground bg-muted h-full overflow-hidden whitespace-pre-wrap break-words rounded p-2 font-mono text-xs ${hasMediaBackground ? "line-clamp-2" : "line-clamp-4"}`}
+              className={`text-muted-foreground bg-muted h-full overflow-hidden rounded p-2 font-mono text-xs break-words whitespace-pre-wrap ${hasMediaBackground ? "line-clamp-2" : "line-clamp-4"}`}
             >
               {contentHasVariables ? renderContentWithVariables(prompt.content) : prompt.content}
             </pre>
           )}
           {showPinButton && (
-            <div className="absolute right-1.5 top-1.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+            <div className="absolute top-1.5 right-1.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
               <PinButton promptId={prompt.id} initialPinned={isPinned} iconOnly />
             </div>
           )}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -20,7 +20,7 @@ interface RequestErrorMetadata {
 export const onRequestError = async (
   error: Error,
   request: RequestErrorMetadata,
-  _context: unknown,
+  _context: unknown
 ) => {
   try {
     const Sentry = await import("@sentry/nextjs");

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -278,10 +278,7 @@ function replacePlaceholders(template: string, prompt: PromptData): string {
   return result;
 }
 
-export async function triggerWebhooks(
-  event: WebhookEvent,
-  prompt: PromptData
-): Promise<void> {
+export async function triggerWebhooks(event: WebhookEvent, prompt: PromptData): Promise<void> {
   try {
     // Get all enabled webhooks for this event
     const webhooks = await db.webhookConfig.findMany({


### PR DESCRIPTION
💡 What:
Added appropriate `aria-label` and `title` attributes using translation strings to various icon-only buttons in the admin table components (`PromptsManagement` and `UsersTable`). Furthermore, the internal decorative SVG icons have been explicitly hidden from screen readers using `aria-hidden="true"`.

🎯 Why:
To ensure assistive technologies (like screen readers) correctly interpret and announce the intended purpose of the buttons (such as "Search", "Open in new tab", "More", "Delete", "Previous", "Next"), rather than ignoring them or announcing confusing redundant internal elements.

📸 Before/After:
*   **Before:** `<Button size="icon"><Search /></Button>` - Poor accessibility and missing tooltips.
*   **After:** `<Button size="icon" aria-label="Search" title="Search"><Search aria-hidden="true" /></Button>` - Excellent accessibility with localized tooltips and clean semantic HTML.

♿ Accessibility:
Significantly improves keyboard and screen-reader accessibility for administrator users interacting with user and prompt management tables.

---
*PR created automatically by Jules for task [7341540584900540309](https://jules.google.com/task/7341540584900540309) started by @billlzzz10*