### PR TITLE
🎨 Palette: Improve accessibility of settings toggles and emojis

### DIFF
--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -200,8 +200,13 @@ export function MusicVolumeSlider() {
           className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
             isPlaying ? "bg-[#22C55E] text-white" : "bg-gray-200 text-gray-600"
           }`}
+          aria-pressed={isPlaying}
         >
-          {isPlaying ? "🔊 On" : "🔇 Off"}
+          {isPlaying ? (
+            <><span aria-hidden="true">🔊</span> On</>
+          ) : (
+            <><span aria-hidden="true">🔇</span> Off</>
+          )}
         </button>
         <span className="text-sm text-[#5D4037]">{Math.round(volume * 100)}%</span>
       </div>

--- a/src/components/kids/layout/settings-modal.tsx
+++ b/src/components/kids/layout/settings-modal.tsx
@@ -168,8 +168,9 @@ function SettingsModal({ onClose }: { onClose: () => void }) {
                     : "border-[#D4A574] bg-white text-[#5D4037] hover:border-[#8B4513]"
                 )}
                 style={{ clipPath: smallPixelClipPath }}
+                aria-pressed={currentLocale === locale.code}
               >
-                <span className="text-lg">{locale.flag}</span>
+                <span className="text-lg" aria-hidden="true">{locale.flag}</span>
                 <span className="text-xs">{locale.label}</span>
               </button>
             ))}
@@ -184,11 +185,15 @@ function SettingsModal({ onClose }: { onClose: () => void }) {
           <h3 className="mb-2 text-lg font-bold text-[#5D4037]">{t("progress")}</h3>
           <div className="flex gap-4 text-[#5D4037]">
             <div>
-              <span className="text-2xl font-bold text-[#FFD700]">⭐ {stars}</span>
+              <span className="text-2xl font-bold text-[#FFD700]">
+                <span aria-hidden="true">⭐</span> {stars}
+              </span>
               <div className="text-xs">{t("stars")}</div>
             </div>
             <div>
-              <span className="text-2xl font-bold text-[#22C55E]">✓ {completed}</span>
+              <span className="text-2xl font-bold text-[#22C55E]">
+                <span aria-hidden="true">✓</span> {completed}
+              </span>
               <div className="text-xs">{t("completed")}</div>
             </div>
           </div>


### PR DESCRIPTION
💡 What: Added `aria-pressed` to toggle buttons (language selection and music volume) and hid decorative emojis (flags, stars, checkmarks, speakers) from screen readers.
🎯 Why: To explicitly convey the active/inactive state of toggles to assistive technology and reduce verbose, unhelpful screen reader readouts of purely visual emojis.
♿ Accessibility:
- Added `aria-pressed` state to `<button>` elements behaving as toggles.
- Added `aria-hidden="true"` wrappers around decorative text and emojis to prevent them from being announced by screen readers.

---
*PR created automatically by Jules for task [6536654288973206559](https://jules.google.com/task/6536654288973206559) started by @billlzzz10*