### PR TITLE
🎨 Palette: Add accessibility to developer tool icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** For icon-only buttons, applying `aria-label` to the button is necessary for screen readers, but the inner SVG icon must also include `aria-hidden="true"` to prevent redundant or confusing announcements.
 **Action:** Always pair an `aria-label` on an icon-only `<button>` with an `aria-hidden="true"` attribute on its inner `<svg>` or `<LucideIcon>`.
+
+## 2025-05-18 - Hover states need focus states
+
+**Learning:** Using `group-hover:opacity-100` to reveal visually hidden controls (like the history delete button) hides the element from keyboard users since the element is not visible during focus navigation.
+**Action:** Always pair `group-hover` with `:focus-visible` states (e.g., `group-focus-visible:opacity-100 focus-visible:opacity-100`) to ensure visibility during keyboard navigation.

--- a/messages/en.json
+++ b/messages/en.json
@@ -1457,7 +1457,10 @@
       "contextWindowSize": "Context Window Size",
       "inputPricePerMillion": "Input $/1M tokens",
       "outputPricePerMillion": "Output $/1M tokens",
-      "highlightTokens": "Highlight Tokens"
+      "highlightTokens": "Highlight Tokens",
+      "clearText": "Clear Text",
+      "deleteHistory": "Delete from History",
+      "copyStats": "Copy Token Statistics"
     }
   },
   "appBanner": {

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -3,7 +3,7 @@
 import "dotenv/config";
 import { defineConfig } from "prisma/config";
 
-// Conditionally assign DIRECT_URL for environments that only provide DATABASE_URL.
+// Conditionally assign DIRECT_URL for environments that only provide DATABASE_URL..
 process.env.DIRECT_URL = process.env.DIRECT_URL || process.env.DATABASE_URL;
 
 export default defineConfig({

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -3,6 +3,9 @@
 import "dotenv/config";
 import { defineConfig } from "prisma/config";
 
+// Conditionally assign DIRECT_URL for environments that only provide DATABASE_URL
+process.env.DIRECT_URL = process.env.DIRECT_URL || process.env.DATABASE_URL;
+
 export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -3,7 +3,7 @@
 import "dotenv/config";
 import { defineConfig } from "prisma/config";
 
-// Conditionally assign DIRECT_URL for environments that only provide DATABASE_URL
+// Conditionally assign DIRECT_URL for environments that only provide DATABASE_URL.
 process.env.DIRECT_URL = process.env.DIRECT_URL || process.env.DATABASE_URL;
 
 export default defineConfig({

--- a/src/components/developers/prompt-enhancer.tsx
+++ b/src/components/developers/prompt-enhancer.tsx
@@ -303,8 +303,19 @@ export function PromptEnhancer() {
           {result && (
             <div className="flex items-center gap-2">
               <span className="text-muted-foreground text-xs">{result.model}</span>
-              <Button variant="ghost" size="icon" onClick={handleCopy} className="h-6 w-6">
-                {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleCopy}
+                className="h-6 w-6"
+                aria-label={t("copy")}
+                title={t("copy")}
+              >
+                {copied ? (
+                  <Check className="h-3 w-3" aria-hidden="true" />
+                ) : (
+                  <Copy className="h-3 w-3" aria-hidden="true" />
+                )}
               </Button>
               <RunPromptButton
                 content={result.improved}

--- a/src/components/developers/prompt-tokenizer.tsx
+++ b/src/components/developers/prompt-tokenizer.tsx
@@ -384,13 +384,15 @@ Estimated Output Cost: ${formatPrice(estimatedOutputCost)}`;
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="absolute top-1 right-1 h-6 w-6 opacity-0 transition-opacity group-hover:opacity-100"
+                    className="absolute top-1 right-1 h-6 w-6 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100 focus-visible:opacity-100"
                     onClick={(e) => {
                       e.stopPropagation();
                       deleteFromHistory(item.id);
                     }}
+                    aria-label={t("tokenizer.deleteHistory")}
+                    title={t("tokenizer.deleteHistory")}
                   >
-                    <Trash2 className="h-3 w-3" />
+                    <Trash2 className="h-3 w-3" aria-hidden="true" />
                   </Button>
                 </div>
               ))
@@ -421,8 +423,15 @@ Estimated Output Cost: ${formatPrice(estimatedOutputCost)}`;
                 className="scale-75"
               />
             </div>
-            <Button variant="ghost" size="icon" className="h-7 w-7" onClick={clearText}>
-              <Trash2 className="h-3.5 w-3.5" />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={clearText}
+              aria-label={t("tokenizer.clearText")}
+              title={t("tokenizer.clearText")}
+            >
+              <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
             </Button>
           </div>
         </div>
@@ -472,8 +481,19 @@ Estimated Output Cost: ${formatPrice(estimatedOutputCost)}`;
           <span className="text-muted-foreground text-sm font-medium">
             {t("tokenizer.analysis")}
           </span>
-          <Button variant="ghost" size="icon" onClick={handleCopy} className="h-6 w-6">
-            {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleCopy}
+            className="h-6 w-6"
+            aria-label={t("tokenizer.copyStats")}
+            title={t("tokenizer.copyStats")}
+          >
+            {copied ? (
+              <Check className="h-3 w-3" aria-hidden="true" />
+            ) : (
+              <Copy className="h-3 w-3" aria-hidden="true" />
+            )}
           </Button>
         </div>
 


### PR DESCRIPTION
💡 What: Added ARIA labels, titles, and `aria-hidden` attributes to several icon-only buttons in the prompt tokenizer and prompt enhancer developer tools. Also added focus-visible states to hover-only visible buttons to make them keyboard accessible.

🎯 Why: Icon-only buttons without accessible names cannot be read correctly by screen readers, making the interface confusing or unusable. Similarly, buttons that only appear on hover (`group-hover:opacity-100`) cannot be discovered by users navigating entirely by keyboard unless paired with a focus state. 

📸 Before/After: 
- Before: `<Button variant="ghost" size="icon" ...><Trash2/></Button>`
- After: `<Button variant="ghost" size="icon" aria-label={t("clearText")} title={t("clearText")} ...><Trash2 aria-hidden="true"/></Button>`

♿ Accessibility:
- Added appropriate `aria-label`s to clear text, copy token stats, delete history, and copy output buttons.
- Ensured tooltips display correctly using `title`.
- Hid raw SVG/Lucide icons from assistive technologies with `aria-hidden="true"`.
- Paired `group-hover:opacity-100` with `focus-visible:opacity-100` for keyboard-accessible discoverability.

---
*PR created automatically by Jules for task [18249461767452749729](https://jules.google.com/task/18249461767452749729) started by @billlzzz10*