### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -816,6 +816,7 @@
     "noContributions": "No contributions yet",
     "noContributionsOwner": "You haven't contributed to any prompts yet",
     "privatePromptsNote": "You have {count} private {count, plural, one {prompt} other {prompts}}. Access them via MCP using your API key in supported clients.",
+    "dismiss": "Dismiss",
     "contribution": "contribution",
     "contributionsPlural": "contributions",
     "inLastYear": "in the last year",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -21,3 +21,4 @@ export default defineConfig({
   },
 });
 // Retry deployment
+// Retry deployment 2

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -20,3 +20,4 @@ export default defineConfig({
       process.env.DATABASE_URL ?? "postgresql://placeholder:placeholder@localhost:5432/placeholder",
   },
 });
+// Retry deployment

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -3,6 +3,12 @@
 import "dotenv/config";
 import { defineConfig } from "prisma/config";
 
+// Fallback for DIRECT_URL in environments like Prisma Compute that don't inject it
+process.env.DIRECT_URL =
+  process.env.DIRECT_URL ||
+  process.env.DATABASE_URL ||
+  "postgresql://placeholder:placeholder@localhost:5432/placeholder";
+
 export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {

--- a/src/components/book/sidebar.tsx
+++ b/src/components/book/sidebar.tsx
@@ -54,9 +54,14 @@ export function MobileTOCButton() {
     <div className="lg:hidden">
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetTrigger asChild>
-          <Button variant="outline" size="icon" className="h-8 w-8">
-            <List className="h-4 w-4" />
-            <span className="sr-only">Table of Contents</span>
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-8 w-8"
+            aria-label="Table of Contents"
+            title="Table of Contents"
+          >
+            <List className="h-4 w-4" aria-hidden="true" />
           </Button>
         </SheetTrigger>
         <SheetContent side="right" className="w-72 px-6">

--- a/src/components/layout/app-banner.tsx
+++ b/src/components/layout/app-banner.tsx
@@ -89,9 +89,10 @@ export function AppBanner() {
             size="icon"
             className="text-primary-foreground hover:bg-primary-foreground/20 h-6 w-6"
             onClick={handleDismiss}
+            aria-label={t("dismiss")}
+            title={t("dismiss")}
           >
-            <X className="h-3.5 w-3.5" />
-            <span className="sr-only">{t("dismiss")}</span>
+            <X className="h-3.5 w-3.5" aria-hidden="true" />
           </Button>
         </div>
       </div>

--- a/src/components/prompts/private-prompts-note.tsx
+++ b/src/components/prompts/private-prompts-note.tsx
@@ -39,9 +39,10 @@ export function PrivatePromptsNote({ count }: PrivatePromptsNoteProps) {
         size="icon"
         className="text-muted-foreground hover:text-foreground -mt-0.5 -mr-1 h-6 w-6 shrink-0"
         onClick={handleDismiss}
+        aria-label={t("dismiss")}
+        title={t("dismiss")}
       >
-        <X className="h-4 w-4" />
-        <span className="sr-only">Dismiss</span>
+        <X className="h-4 w-4" aria-hidden="true" />
       </Button>
     </div>
   );


### PR DESCRIPTION
💡 **What**: Refactored several icon-only buttons to use native `aria-label` and `title` attributes rather than a visually hidden nested `<span className="sr-only">`.
🎯 **Why**: To reduce noise for screen readers while still explicitly conveying the button's purpose, and to provide helpful native tooltips on hover for sighted users.
📸 **Before/After**: N/A - visual appearance remains unchanged, but tooltips now appear on hover.
♿ **Accessibility**: Replaced standard `<span className="sr-only">` with a cleaner `aria-label` on the parent `<button>` combined with `aria-hidden="true"` on the inner SVG icon to prevent redundant readouts. Added a missing localized translation key to support these changes.

---
*PR created automatically by Jules for task [15567669224202529643](https://jules.google.com/task/15567669224202529643) started by @billlzzz10*