### PR TITLE
🎨 Palette: Improve accessibility for toggle buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 
 **Learning:** For icon-only buttons, applying `aria-label` to the button is necessary for screen readers, but the inner SVG icon must also include `aria-hidden="true"` to prevent redundant or confusing announcements.
 **Action:** Always pair an `aria-label` on an icon-only `<button>` with an `aria-hidden="true"` attribute on its inner `<svg>` or `<LucideIcon>`.
+
+## 2026-04-27 - Add aria-pressed and focus styles to standard toggle buttons
+**Learning:** Custom toggle buttons and language selection groups built with standard HTML `<button>` elements in this app frequently lack the `aria-pressed` attribute to indicate active state to assistive technology, and miss explicit focus styling for keyboard navigation.
+**Action:** Always apply `aria-pressed={boolean}` to single switch toggles or grouped selectable buttons, and pair them with explicit focus visibility (e.g., `focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-offset-2`).

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** Always pair an `aria-label` on an icon-only `<button>` with an `aria-hidden="true"` attribute on its inner `<svg>` or `<LucideIcon>`.
 
 ## 2026-04-27 - Add aria-pressed and focus styles to standard toggle buttons
+
 **Learning:** Custom toggle buttons and language selection groups built with standard HTML `<button>` elements in this app frequently lack the `aria-pressed` attribute to indicate active state to assistive technology, and miss explicit focus styling for keyboard navigation.
 **Action:** Always apply `aria-pressed={boolean}` to single switch toggles or grouped selectable buttons, and pair them with explicit focus visibility (e.g., `focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-offset-2`).

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -3,10 +3,6 @@
 import "dotenv/config";
 import { defineConfig } from "prisma/config";
 
-if (process.env.DATABASE_URL && !process.env.DIRECT_URL) {
-  process.env.DIRECT_URL = process.env.DATABASE_URL;
-}
-
 export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {
@@ -14,6 +10,7 @@ export default defineConfig({
   },
   engine: "classic",
   datasource: {
-    url: process.env.DATABASE_URL,
+    url:
+      process.env.DATABASE_URL ?? "postgresql://placeholder:placeholder@localhost:5432/placeholder",
   },
 });

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -14,7 +14,6 @@ export default defineConfig({
   },
   engine: "classic",
   datasource: {
-    url:
-      process.env.DATABASE_URL ?? "postgresql://placeholder:placeholder@localhost:5432/placeholder",
+    url: process.env.DATABASE_URL,
   },
 });

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -3,6 +3,10 @@
 import "dotenv/config";
 import { defineConfig } from "prisma/config";
 
+if (process.env.DATABASE_URL && !process.env.DIRECT_URL) {
+  process.env.DIRECT_URL = process.env.DATABASE_URL;
+}
+
 export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {

--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -175,7 +175,8 @@ export function MusicButton() {
   return (
     <button
       onClick={toggleMusic}
-      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5"
+      aria-pressed={isPlaying}
+      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
       aria-label={labelText}
       title={labelText}
     >
@@ -197,7 +198,8 @@ export function MusicVolumeSlider() {
       <div className="flex items-center justify-between">
         <button
           onClick={() => setIsPlaying(!isPlaying)}
-          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+          aria-pressed={isPlaying}
+          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none ${
             isPlaying ? "bg-[#22C55E] text-white" : "bg-gray-200 text-gray-600"
           }`}
         >

--- a/src/components/kids/layout/settings-modal.tsx
+++ b/src/components/kids/layout/settings-modal.tsx
@@ -161,8 +161,9 @@ function SettingsModal({ onClose }: { onClose: () => void }) {
               <button
                 key={locale.code}
                 onClick={() => handleLanguageChange(locale.code)}
+                aria-pressed={currentLocale === locale.code}
                 className={cn(
-                  "flex items-center gap-2 border-2 p-2 text-sm font-medium transition-all",
+                  "flex items-center gap-2 border-2 p-2 text-sm font-medium transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none",
                   currentLocale === locale.code
                     ? "border-[#5D4037] bg-[#8B4513] text-white"
                     : "border-[#D4A574] bg-white text-[#5D4037] hover:border-[#8B4513]"


### PR DESCRIPTION
💡 What: Added `aria-pressed` states and `focus-visible` styles to custom `<button>` toggle elements in the application. Specifically modified the background music buttons and the language selection flags.
🎯 Why: Toggle buttons and selection groups made from standard `<button>` elements don't inherently communicate their active/selected state to screen readers. Adding `aria-pressed` fixes this. Adding `focus-visible` ensures clear visual feedback for keyboard users navigating through settings.
📸 Before/After: Visual changes are only apparent on keyboard focus (which now displays a focus ring).
♿ Accessibility: Improves screen reader compatibility for settings toggles and enhances keyboard navigation visibility.

---
*PR created automatically by Jules for task [5460164176873316396](https://jules.google.com/task/5460164176873316396) started by @billlzzz10*