### PR TITLE
🎨 Palette: Improve accessibility in MCP server popup controls

### DIFF
--- a/src/components/mcp/mcp-server-popup.tsx
+++ b/src/components/mcp/mcp-server-popup.tsx
@@ -44,6 +44,7 @@ export function McpServerPopup({
   showOfficialBranding = false,
 }: McpServerPopupProps) {
   const t = useTranslations("mcp");
+  const tCommon = useTranslations("common");
   const { data: session } = useSession();
   const [isOpen, setIsOpen] = useState(false);
   const [filtersOpen, setFiltersOpen] = useState(false);
@@ -148,6 +149,7 @@ export function McpServerPopup({
             <div className="flex gap-0.5">
               <button
                 onClick={() => setMcpMode("remote")}
+                aria-pressed={mcpMode === "remote"}
                 className={cn(
                   "rounded px-2 py-1 text-[11px] font-medium transition-colors",
                   mcpMode === "remote"
@@ -159,6 +161,7 @@ export function McpServerPopup({
               </button>
               <button
                 onClick={() => setMcpMode("local")}
+                aria-pressed={mcpMode === "local"}
                 className={cn(
                   "rounded px-2 py-1 text-[11px] font-medium transition-colors",
                   mcpMode === "local"
@@ -199,10 +202,12 @@ export function McpServerPopup({
           <div className="border-t pt-2">
             <button
               onClick={() => setFiltersOpen(!filtersOpen)}
+              aria-expanded={filtersOpen}
               className="text-muted-foreground hover:text-foreground flex w-full items-center justify-between text-[11px] transition-colors"
             >
               <span>{t("customizeFilters")}</span>
               <ChevronDown
+                aria-hidden="true"
                 className={cn("h-3 w-3 transition-transform", filtersOpen && "rotate-180")}
               />
             </button>
@@ -235,9 +240,10 @@ export function McpServerPopup({
                           @{user}
                           <button
                             onClick={() => removeUser(user)}
+                            aria-label={`${tCommon("delete")} @${user}`}
                             className="hover:text-destructive"
                           >
-                            <X className="h-2.5 w-2.5" />
+                            <X aria-hidden="true" className="h-2.5 w-2.5" />
                           </button>
                         </Badge>
                       ))}
@@ -276,9 +282,10 @@ export function McpServerPopup({
                           {cat}
                           <button
                             onClick={() => removeCategory(cat)}
+                            aria-label={`${tCommon("delete")} ${cat}`}
                             className="hover:text-destructive"
                           >
-                            <X className="h-2.5 w-2.5" />
+                            <X aria-hidden="true" className="h-2.5 w-2.5" />
                           </button>
                         </Badge>
                       ))}
@@ -310,8 +317,12 @@ export function McpServerPopup({
                           className="h-5 gap-0.5 pr-0.5 text-[10px]"
                         >
                           {tag}
-                          <button onClick={() => removeTag(tag)} className="hover:text-destructive">
-                            <X className="h-2.5 w-2.5" />
+                          <button
+                            onClick={() => removeTag(tag)}
+                            aria-label={`${tCommon("delete")} ${tag}`}
+                            className="hover:text-destructive"
+                          >
+                            <X aria-hidden="true" className="h-2.5 w-2.5" />
                           </button>
                         </Badge>
                       ))}


### PR DESCRIPTION
💡 **What**: Added accessibility attributes to several interactive elements in the `McpServerPopup` component. Specifically:
- Added `aria-pressed` to the "Remote" and "Local" toggle buttons to reflect their active states.
- Added `aria-expanded` to the "Customize filters" toggle button to reflect the accordion's visibility state, and `aria-hidden="true"` to its decorative chevron icon.
- Added localized `aria-label`s to the "remove user/category/tag" buttons for screen readers, and `aria-hidden="true"` to their inner 'X' icons to prevent redundant announcements.

🎯 **Why**: To ensure users employing assistive technologies (like screen readers) can fully understand the state and purpose of the MCP configuration controls. Without these attributes, screen readers may announce ambiguous icons or fail to convey critical state changes (like toggling a filter section).

📸 **Before/After**: (Visual change not applicable, purely semantic HTML changes).

♿ **Accessibility**: Significant improvement in screen reader experience for the MCP Server Configuration feature by adhering to WAI-ARIA authoring practices for toggle buttons, accordions, and icon-only buttons.

---
*PR created automatically by Jules for task [16439218757150279979](https://jules.google.com/task/16439218757150279979) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved accessibility in `McpServerPopup` by adding ARIA attributes so screen readers convey control states and purposes clearly. Toggles now use aria-pressed, the filters accordion uses aria-expanded, decorative icons are aria-hidden, and remove buttons have localized aria-labels.

<sup>Written for commit 1b1a2557b40efc66910ee4abcee873be16e9ee1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

