### PR TITLE
🎨 Palette: Improve music toggle button accessibility

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -3,6 +3,10 @@
 import "dotenv/config";
 import { defineConfig } from "prisma/config";
 
+if (process.env.DATABASE_URL && !process.env.DIRECT_URL) {
+  process.env.DIRECT_URL = process.env.DATABASE_URL;
+}
+
 export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -3,10 +3,6 @@
 import "dotenv/config";
 import { defineConfig } from "prisma/config";
 
-if (process.env.DATABASE_URL && !process.env.DIRECT_URL) {
-  process.env.DIRECT_URL = process.env.DATABASE_URL;
-}
-
 export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {

--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -197,11 +197,20 @@ export function MusicVolumeSlider() {
       <div className="flex items-center justify-between">
         <button
           onClick={() => setIsPlaying(!isPlaying)}
-          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+          aria-pressed={isPlaying}
+          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none ${
             isPlaying ? "bg-[#22C55E] text-white" : "bg-gray-200 text-gray-600"
           }`}
         >
-          {isPlaying ? "🔊 On" : "🔇 Off"}
+          {isPlaying ? (
+            <>
+              <span aria-hidden="true">🔊</span> On
+            </>
+          ) : (
+            <>
+              <span aria-hidden="true">🔇</span> Off
+            </>
+          )}
         </button>
         <span className="text-sm text-[#5D4037]">{Math.round(volume * 100)}%</span>
       </div>


### PR DESCRIPTION
💡 **What:** Improved the accessibility of the music toggle button (`MusicVolumeSlider`) in the kids settings by adding an `aria-pressed` state, proper keyboard focus classes, and wrapping decorative emojis in `<span aria-hidden="true">`.

🎯 **Why:** Custom `<button>` elements acting as toggles should use `aria-pressed` to indicate their state to screen readers. Focus styles improve navigation for keyboard users. Hiding the emojis prevents screen readers from redundantly announcing visual embellishments alongside the main "On" or "Off" text.

📸 **Before/After:**
- Before: `<button className="..."> {isPlaying ? "🔊 On" : "🔇 Off"} </button>`
- After: `<button aria-pressed={isPlaying} className="... focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"> {isPlaying ? <><span aria-hidden="true">🔊</span> On</> : ...} </button>`

♿ **Accessibility:**
- Added `aria-pressed` to indicate toggle state.
- Added explicit `focus-visible` ring styles.
- Added `aria-hidden="true"` to emojis to prevent confusing screen reader announcements.

---
*PR created automatically by Jules for task [10966997404466373050](https://jules.google.com/task/10966997404466373050) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve accessibility of the kids settings music toggle (`MusicVolumeSlider`) by adding `aria-pressed`, `focus-visible` ring styles for keyboard users, and hiding decorative emojis with `<span aria-hidden="true">`. This clarifies toggle state for screen readers and improves focus visibility.

<sup>Written for commit aa6e10b1dee98080d5f8ff2917c26f39cdf37c7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

