### PR TITLE
🎨 Palette: Add keyboard focus states and ARIA to kids layout buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,8 @@
 
 **Learning:** For custom toggle buttons or selectable elements acting as a group (like language selection) that use standard HTML `<button>` tags, `aria-pressed={boolean}` should be applied to convey the active state to assistive technology. Furthermore, when decorative emojis are used alongside text labels, wrapping the emoji in a `<span>` with `aria-hidden="true"` prevents redundant or confusing screen reader announcements.
 **Action:** Always apply `aria-pressed` to custom toggle buttons and add `aria-hidden="true"` to wrapper spans around decorative emojis.
+
+## 2026-06-15 - Add focus-visible rings to custom interactive elements for keyboard accessibility
+
+**Learning:** When creating custom interactive elements (like `pixel-btn` instances) that eschew standard browser focus outlines, failing to provide explicit focus indicators breaks keyboard accessibility. Using the `focus-visible:` variant (e.g., `focus-visible:ring-2 focus-visible:outline-none`) ensures that users navigating via keyboard can clearly see their focus state, while preventing the focus ring from appearing when mouse users click the elements.
+**Action:** Always verify that custom buttons and links have explicit `focus-visible:ring-2` styles applied to maintain keyboard accessibility without sacrificing visual aesthetics for pointing devices.

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -3,10 +3,6 @@
 import "dotenv/config";
 import { defineConfig } from "prisma/config";
 
-if (process.env.DATABASE_URL && !process.env.DIRECT_URL) {
-  process.env.DIRECT_URL = process.env.DATABASE_URL;
-}
-
 export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {
@@ -14,7 +10,7 @@ export default defineConfig({
   },
   engine: "classic",
   datasource: {
-    // @ts-expect-error Allow undefined url instead of static placeholder
-    url: process.env.DATABASE_URL,
+    url:
+      process.env.DATABASE_URL ?? "postgresql://placeholder:placeholder@localhost:5432/placeholder",
   },
 });

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -3,6 +3,10 @@
 import "dotenv/config";
 import { defineConfig } from "prisma/config";
 
+if (process.env.DATABASE_URL && !process.env.DIRECT_URL) {
+  process.env.DIRECT_URL = process.env.DATABASE_URL;
+}
+
 export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {
@@ -10,7 +14,7 @@ export default defineConfig({
   },
   engine: "classic",
   datasource: {
-    url:
-      process.env.DATABASE_URL ?? "postgresql://placeholder:placeholder@localhost:5432/placeholder",
+    // @ts-expect-error Allow undefined url instead of static placeholder
+    url: process.env.DATABASE_URL,
   },
 });

--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -175,7 +175,8 @@ export function MusicButton() {
   return (
     <button
       onClick={toggleMusic}
-      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5"
+      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5 focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:ring-offset-1 focus-visible:outline-none"
+      aria-pressed={isPlaying}
       aria-label={labelText}
       title={labelText}
     >

--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -175,7 +175,7 @@ export function MusicButton() {
   return (
     <button
       onClick={toggleMusic}
-      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5 focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:ring-offset-1 focus-visible:outline-none"
+      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5 focus-visible:ring-2 focus-visible:ring-amber-900 focus-visible:ring-offset-1 focus-visible:outline-none"
       aria-pressed={isPlaying}
       aria-label={labelText}
       title={labelText}

--- a/src/components/kids/layout/kids-header.tsx
+++ b/src/components/kids/layout/kids-header.tsx
@@ -82,7 +82,7 @@ export function KidsHeader() {
             <SettingsButton />
             <a
               href="/kids"
-              className="pixel-btn flex h-8 items-center px-3 py-1.5 text-sm"
+              className="pixel-btn flex h-8 items-center px-3 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:ring-offset-1 focus-visible:outline-none"
               aria-label={t("header.home")}
               title={t("header.home")}
             >
@@ -90,7 +90,7 @@ export function KidsHeader() {
             </a>
             <Link
               href="/kids/map"
-              className="pixel-btn pixel-btn-green flex h-8 items-center px-3 py-1.5 text-sm"
+              className="pixel-btn pixel-btn-green flex h-8 items-center px-3 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:ring-offset-1 focus-visible:outline-none"
               aria-label={t("level.map")}
               title={t("level.map")}
             >
@@ -99,7 +99,7 @@ export function KidsHeader() {
             {/* Back to main site */}
             <a
               href="/"
-              className="pixel-btn pixel-btn-amber hidden h-8 items-center px-3 py-1.5 text-sm md:flex"
+              className="pixel-btn pixel-btn-amber hidden h-8 items-center px-3 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:ring-offset-1 focus-visible:outline-none md:flex"
             >
               {t("header.mainSite")}
             </a>
@@ -109,7 +109,7 @@ export function KidsHeader() {
           <div className="relative sm:hidden" ref={menuRef}>
             <button
               onClick={() => setMenuOpen(!menuOpen)}
-              className="pixel-btn flex h-8 items-center px-3 py-1.5"
+              className="pixel-btn flex h-8 items-center px-3 py-1.5 focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:ring-offset-1 focus-visible:outline-none"
               aria-label={t("header.menu") || "Menu"}
               title={t("header.menu") || "Menu"}
             >

--- a/src/components/kids/layout/kids-header.tsx
+++ b/src/components/kids/layout/kids-header.tsx
@@ -82,7 +82,7 @@ export function KidsHeader() {
             <SettingsButton />
             <a
               href="/kids"
-              className="pixel-btn flex h-8 items-center px-3 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:ring-offset-1 focus-visible:outline-none"
+              className="pixel-btn flex h-8 items-center px-3 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-amber-900 focus-visible:ring-offset-1 focus-visible:outline-none"
               aria-label={t("header.home")}
               title={t("header.home")}
             >
@@ -90,7 +90,7 @@ export function KidsHeader() {
             </a>
             <Link
               href="/kids/map"
-              className="pixel-btn pixel-btn-green flex h-8 items-center px-3 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:ring-offset-1 focus-visible:outline-none"
+              className="pixel-btn pixel-btn-green flex h-8 items-center px-3 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-amber-900 focus-visible:ring-offset-1 focus-visible:outline-none"
               aria-label={t("level.map")}
               title={t("level.map")}
             >
@@ -99,7 +99,7 @@ export function KidsHeader() {
             {/* Back to main site */}
             <a
               href="/"
-              className="pixel-btn pixel-btn-amber hidden h-8 items-center px-3 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:ring-offset-1 focus-visible:outline-none md:flex"
+              className="pixel-btn pixel-btn-amber hidden h-8 items-center px-3 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-amber-900 focus-visible:ring-offset-1 focus-visible:outline-none md:flex"
             >
               {t("header.mainSite")}
             </a>
@@ -109,7 +109,7 @@ export function KidsHeader() {
           <div className="relative sm:hidden" ref={menuRef}>
             <button
               onClick={() => setMenuOpen(!menuOpen)}
-              className="pixel-btn flex h-8 items-center px-3 py-1.5 focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:ring-offset-1 focus-visible:outline-none"
+              className="pixel-btn flex h-8 items-center px-3 py-1.5 focus-visible:ring-2 focus-visible:ring-amber-900 focus-visible:ring-offset-1 focus-visible:outline-none"
               aria-label={t("header.menu") || "Menu"}
               title={t("header.menu") || "Menu"}
             >

--- a/src/components/kids/layout/settings-modal.tsx
+++ b/src/components/kids/layout/settings-modal.tsx
@@ -163,7 +163,7 @@ function SettingsModal({ onClose }: { onClose: () => void }) {
                 onClick={() => handleLanguageChange(locale.code)}
                 aria-pressed={currentLocale === locale.code}
                 className={cn(
-                  "flex items-center gap-2 border-2 p-2 text-sm font-medium transition-all focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:ring-offset-1 focus-visible:outline-none",
+                  "flex items-center gap-2 border-2 p-2 text-sm font-medium transition-all focus-visible:ring-2 focus-visible:ring-amber-900 focus-visible:ring-offset-1 focus-visible:outline-none",
                   currentLocale === locale.code
                     ? "border-[#5D4037] bg-[#8B4513] text-white"
                     : "border-[#D4A574] bg-white text-[#5D4037] hover:border-[#8B4513]"


### PR DESCRIPTION
💡 What: Added explicit keyboard focus states (`focus-visible:ring-2`) and ARIA pressed attributes to interactive `pixel-btn` custom elements in the Kids layout components.
🎯 Why: Custom styled buttons often remove native browser focus rings. Without explicitly replacing them, users relying on keyboard navigation cannot see which element has focus, breaking accessibility.
📸 Before/After: Visual changes only appear for keyboard users (tabbing). Mouse users see no changes.
♿ Accessibility:
- Added `aria-pressed={isPlaying}` to the background music toggle to properly announce its state to screen readers.
- Restored visual focus indicators for keyboard users across the main kids header navigation and music toggle using standard Tailwind `focus-visible` utilities.

---
*PR created automatically by Jules for task [13878564037783761297](https://jules.google.com/task/13878564037783761297) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit keyboard focus rings and `aria-pressed` to Kids layout buttons to restore keyboard and screen reader support. Also documents the `focus-visible` pattern in `.Jules/palette.md` and standardizes ring color to `ring-amber-900`.

- **New Features**
  - `MusicButton`: add `aria-pressed` and `focus-visible:ring-2 ring-amber-900 ring-offset-1`.
  - `kids-header`: apply `focus-visible` ring styles to home, map, menu, and main-site buttons.
  - `settings-modal`: standardize focus ring to `ring-amber-900` for language buttons.
  - Docs: add guidance on using `focus-visible` rings for custom interactive elements.

- **Refactors**
  - Reverted out-of-scope `prisma.config.ts` changes.

<sup>Written for commit e8ff04774b3332e4bf38394d464d0c698b7aa1d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

