### PR TITLE
🎨 Palette: Add aria-expanded to mobile menu button

### DIFF
--- a/src/components/kids/layout/kids-header.tsx
+++ b/src/components/kids/layout/kids-header.tsx
@@ -112,6 +112,7 @@ export function KidsHeader() {
               className="pixel-btn flex h-8 items-center px-3 py-1.5"
               aria-label={t("header.menu") || "Menu"}
               title={t("header.menu") || "Menu"}
+              aria-expanded={menuOpen}
             >
               <PixelMenuIcon aria-hidden="true" />
             </button>


### PR DESCRIPTION
💡 **What:** Added `aria-expanded={menuOpen}` to the mobile menu `<button>` in `KidsHeader`.
🎯 **Why:** To improve accessibility by clearly conveying the menu's visibility state to assistive technologies, making the navigation more intuitive for all users.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers can now accurately announce whether the mobile menu is open or closed when the toggle button is focused or activated.

---
*PR created automatically by Jules for task [12581492711134455737](https://jules.google.com/task/12581492711134455737) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `aria-expanded={menuOpen}` to the `KidsHeader` mobile menu button so assistive technologies announce whether the menu is open or closed. No UI changes.

<sup>Written for commit e128d2213ea0ba2ecb17e03e35262ac640b4c0e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

