### PR TITLE
🎨 Palette: Enhance sidebar keyboard accessibility and screen reader experience

### DIFF
--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -46,7 +46,7 @@ export function Sidebar() {
       {/* Logo / Brand */}
       <div className="mb-8">
         <div className="flex h-8 w-8 items-center justify-center rounded-sm border border-white/20 bg-white/10">
-          <Terminal size={16} className="text-agent-cyan" />
+          <Terminal size={16} className="text-agent-cyan" aria-hidden="true" />
         </div>
       </div>
 
@@ -60,15 +60,18 @@ export function Sidebar() {
               href={item.href}
               aria-label={item.label}
               className={cn(
-                "group relative flex items-center justify-center rounded-md p-3 transition-all duration-300",
+                "group relative flex items-center justify-center rounded-md p-3 transition-all duration-300 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none",
                 isActive
                   ? "bg-white/10 text-white shadow-[0_0_15px_rgba(255,255,255,0.1)]"
                   : "text-white/40 hover:bg-white/5 hover:text-white"
               )}
             >
-              <item.icon size={20} />
+              <item.icon size={20} aria-hidden="true" />
               {/* Tooltip on Hover */}
-              <span className="pointer-events-none absolute left-14 z-50 rounded border border-white/10 bg-black/80 px-2 py-1 text-xs whitespace-nowrap opacity-0 backdrop-blur-md transition-opacity group-hover:opacity-100">
+              <span
+                aria-hidden="true"
+                className="pointer-events-none absolute left-14 z-50 rounded border border-white/10 bg-black/80 px-2 py-1 text-xs whitespace-nowrap opacity-0 backdrop-blur-md transition-opacity group-hover:opacity-100"
+              >
                 {item.label}
               </span>
             </Link>
@@ -80,11 +83,14 @@ export function Sidebar() {
       <div className="mt-auto flex w-full flex-col items-center gap-3 px-4">
         <button
           onClick={toggleLanguage}
-          className="group relative mb-2 rounded-md p-3 text-white/40 transition-all hover:bg-white/5 hover:text-white"
+          className="group relative mb-2 rounded-md p-3 text-white/40 transition-all hover:bg-white/5 hover:text-white focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
           aria-label="Toggle Language"
         >
-          <Globe size={20} />
-          <span className="pointer-events-none absolute left-14 z-50 rounded border border-white/10 bg-black/80 px-2 py-1 font-mono text-[10px] whitespace-nowrap uppercase opacity-0 backdrop-blur-md transition-opacity group-hover:opacity-100">
+          <Globe size={20} aria-hidden="true" />
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute left-14 z-50 rounded border border-white/10 bg-black/80 px-2 py-1 font-mono text-[10px] whitespace-nowrap uppercase opacity-0 backdrop-blur-md transition-opacity group-hover:opacity-100"
+          >
             Toggle EN/TH
           </span>
         </button>
@@ -94,7 +100,9 @@ export function Sidebar() {
         {activeAgents.map((agent) => (
           <div
             key={agent.name}
-            className="group relative flex w-full justify-center"
+            className="group relative flex w-full justify-center rounded-sm focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
+            tabIndex={0}
+            aria-label={`${agent.name} status: ${agent.status}`}
             data-testid="agent-status-indicator"
           >
             <div
@@ -106,7 +114,10 @@ export function Sidebar() {
                   : "opacity-30"
               )}
             />
-            <span className="pointer-events-none absolute top-1/2 left-10 z-50 -translate-y-1/2 rounded border border-white/10 bg-black/80 px-2 py-1 font-mono text-[10px] whitespace-nowrap opacity-0 backdrop-blur-md transition-opacity group-hover:opacity-100">
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute top-1/2 left-10 z-50 -translate-y-1/2 rounded border border-white/10 bg-black/80 px-2 py-1 font-mono text-[10px] whitespace-nowrap opacity-0 backdrop-blur-md transition-opacity group-hover:opacity-100"
+            >
               {agent.name}: {agent.status.toUpperCase()}
             </span>
           </div>


### PR DESCRIPTION
**💡 What:**
Added `focus-visible` styles to all interactive elements within the Sidebar (navigation links, language toggle, and agent status indicators) and improved ARIA attributes for screen readers.

**🎯 Why:**
Sighted keyboard users need clear visible focus rings to navigate the sidebar effectively. Screen reader users need to be able to focus the agent status indicators and not have decorative icons/tooltips read redundantly.

**📸 Before/After:**
*(See generated screenshot for focus rings)*

**♿ Accessibility:**
- Added `focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none` for keyboard navigation on interactive elements.
- Added `aria-hidden="true"` to decorative icons (Terminal, Globe, nav item icons) and redundant tooltip spans since they are already covered by `aria-label`.
- Added `tabIndex={0}` and a descriptive `aria-label` to agent status indicator bars to make them discoverable.

---
*PR created automatically by Jules for task [6868429313817142191](https://jules.google.com/task/6868429313817142191) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves sidebar keyboard navigation and screen reader support by adding visible focus rings and clear ARIA semantics. Keyboard users see focus outlines; screen readers ignore decorative icons and announce agent status.

- **Accessibility**
  - Added `focus-visible` ring styles to nav links, the language toggle, and agent status rows.
  - Set decorative icons and hover tooltips to `aria-hidden="true"`.
  - Made agent status indicators focusable with `tabIndex={0}` and added `aria-label` announcing name and status.

<sup>Written for commit 8c74b4867f844cf0662d4cfc4c8767aca71f1aa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

