### PR TITLE
🎨 Palette: Enhance keyboard accessibility for Kids UI header elements

### DIFF
--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -175,7 +175,8 @@ export function MusicButton() {
   return (
     <button
       onClick={toggleMusic}
-      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5"
+      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5 focus-visible:ring-2 focus-visible:ring-[#FFD700] focus-visible:ring-offset-2 focus-visible:outline-none"
+      aria-pressed={isPlaying}
       aria-label={labelText}
       title={labelText}
     >

--- a/src/components/kids/layout/kids-header.tsx
+++ b/src/components/kids/layout/kids-header.tsx
@@ -82,7 +82,7 @@ export function KidsHeader() {
             <SettingsButton />
             <a
               href="/kids"
-              className="pixel-btn flex h-8 items-center px-3 py-1.5 text-sm"
+              className="pixel-btn flex h-8 items-center px-3 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-[#FFD700] focus-visible:ring-offset-2 focus-visible:outline-none"
               aria-label={t("header.home")}
               title={t("header.home")}
             >
@@ -90,7 +90,7 @@ export function KidsHeader() {
             </a>
             <Link
               href="/kids/map"
-              className="pixel-btn pixel-btn-green flex h-8 items-center px-3 py-1.5 text-sm"
+              className="pixel-btn pixel-btn-green flex h-8 items-center px-3 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-[#FFD700] focus-visible:ring-offset-2 focus-visible:outline-none"
               aria-label={t("level.map")}
               title={t("level.map")}
             >
@@ -99,7 +99,7 @@ export function KidsHeader() {
             {/* Back to main site */}
             <a
               href="/"
-              className="pixel-btn pixel-btn-amber hidden h-8 items-center px-3 py-1.5 text-sm md:flex"
+              className="pixel-btn pixel-btn-amber hidden h-8 items-center px-3 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-[#FFD700] focus-visible:ring-offset-2 focus-visible:outline-none md:flex"
             >
               {t("header.mainSite")}
             </a>
@@ -109,7 +109,9 @@ export function KidsHeader() {
           <div className="relative sm:hidden" ref={menuRef}>
             <button
               onClick={() => setMenuOpen(!menuOpen)}
-              className="pixel-btn flex h-8 items-center px-3 py-1.5"
+              className="pixel-btn flex h-8 items-center px-3 py-1.5 focus-visible:ring-2 focus-visible:ring-[#FFD700] focus-visible:ring-offset-2 focus-visible:outline-none"
+              aria-expanded={menuOpen}
+              aria-controls="mobile-menu"
               aria-label={t("header.menu") || "Menu"}
               title={t("header.menu") || "Menu"}
             >
@@ -118,7 +120,10 @@ export function KidsHeader() {
 
             {/* Mobile dropdown menu */}
             {menuOpen && (
-              <div className="animate-in fade-in slide-in-from-top-2 absolute top-full right-0 z-50 mt-2 w-48 rounded-lg border-4 border-[#8B4513] bg-[#2C1810] shadow-xl duration-200">
+              <div
+                id="mobile-menu"
+                className="animate-in fade-in slide-in-from-top-2 absolute top-full right-0 z-50 mt-2 w-48 rounded-lg border-4 border-[#8B4513] bg-[#2C1810] shadow-xl duration-200"
+              >
                 <div className="flex flex-col gap-2 p-2">
                   {/* Progress - mobile only */}
                   <div className="pixel-border-sm flex items-center justify-center gap-1 border-2 border-[#8B4513] bg-[#4A3728] px-3 py-2">
@@ -134,23 +139,23 @@ export function KidsHeader() {
 
                   <a
                     href="/kids"
-                    className="pixel-btn flex items-center justify-center gap-2 px-3 py-2 text-sm"
+                    className="pixel-btn flex items-center justify-center gap-2 px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-[#FFD700] focus-visible:ring-offset-2 focus-visible:outline-none"
                     onClick={() => setMenuOpen(false)}
                   >
-                    <PixelHomeIcon />
+                    <PixelHomeIcon aria-hidden="true" />
                     {t("header.home")}
                   </a>
                   <Link
                     href="/kids/map"
-                    className="pixel-btn pixel-btn-green flex items-center justify-center gap-2 px-3 py-2 text-sm"
+                    className="pixel-btn pixel-btn-green flex items-center justify-center gap-2 px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-[#FFD700] focus-visible:ring-offset-2 focus-visible:outline-none"
                     onClick={() => setMenuOpen(false)}
                   >
-                    <PixelMapIcon />
+                    <PixelMapIcon aria-hidden="true" />
                     {t("level.map")}
                   </Link>
                   <a
                     href="/"
-                    className="pixel-btn pixel-btn-amber flex items-center justify-center px-3 py-2 text-sm"
+                    className="pixel-btn pixel-btn-amber flex items-center justify-center px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-[#FFD700] focus-visible:ring-offset-2 focus-visible:outline-none"
                     onClick={() => setMenuOpen(false)}
                   >
                     {t("header.mainSite")}

--- a/src/components/kids/layout/settings-modal.tsx
+++ b/src/components/kids/layout/settings-modal.tsx
@@ -40,9 +40,11 @@ export function SettingsButton() {
           setIsOpen(true);
           analyticsKids.openSettings();
         }}
-        className="pixel-btn pixel-btn-purple flex h-8 items-center px-3 py-1.5 text-sm"
+        className="pixel-btn pixel-btn-purple flex h-8 items-center px-3 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-[#FFD700] focus-visible:ring-offset-2 focus-visible:outline-none"
         aria-label={t("title") || "Settings"}
         title={t("title") || "Settings"}
+        aria-expanded={isOpen}
+        aria-haspopup="dialog"
       >
         <PixelSettingsIcon aria-hidden="true" />
       </button>


### PR DESCRIPTION
**💡 What:** 
Added explicit keyboard focus rings (`focus-visible:ring-[#FFD700]`) to all interactive elements within the Kids UI header (`KidsHeader`, `MusicButton`, and `SettingsButton`). In addition, proper ARIA attributes (`aria-expanded`, `aria-controls`, `aria-haspopup`, and `aria-pressed`) were added to mobile menu dropdowns, the settings modal trigger, and the music toggle to better communicate state to assistive technology.

**🎯 Why:**
The `pixel-btn` style intentionally removes the native browser focus outline to preserve the pixel-art aesthetic, but this resulted in a complete lack of visual feedback for keyboard users navigating the header. Furthermore, the missing stateful ARIA attributes meant screen readers couldn't identify if menus were open or if the music was toggled on/off.

**📸 Before/After:**
*Before:* Tabbing through the header provided no visible indicator of the active element, and screen readers read toggles as generic buttons without state.
*After:* A high-contrast yellow focus ring (`#FFD700`) correctly matches the Kids UI theme and provides clear visual feedback on focus, while screen readers now announce the toggled/expanded states.

**♿ Accessibility:**
- Restored visual focus indicators for keyboard users (`focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-offset-2`).
- Added `aria-pressed` for the `MusicButton`.
- Added `aria-expanded` and `aria-controls` for the mobile dropdown menu.
- Added `aria-expanded` and `aria-haspopup` for the `SettingsButton`.
- Hid decorative icons from screen readers using `aria-hidden="true"`.

---
*PR created automatically by Jules for task [9432200916299054313](https://jules.google.com/task/9432200916299054313) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved keyboard accessibility in the Kids UI header by adding visible focus rings and stateful ARIA attributes across the header and mobile menu. Keyboard users get a clear yellow focus ring, and screen readers announce menu, dialog, and toggle states.

- **New Features**
  - Added focus-visible yellow ring (#FFD700) to all header and mobile menu buttons/links (`KidsHeader`, `MusicButton`, `SettingsButton`, menu items).
  - Wired ARIA state: `aria-pressed` on music toggle; `aria-expanded` + `aria-controls="mobile-menu"` on the menu button with matching `id`; `aria-expanded` + `aria-haspopup="dialog"` on the settings button.
  - Hid decorative icons with `aria-hidden="true"`.

<sup>Written for commit 7bc92c2b68dc6c7dbe8c9191d1c9f097fa714a96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

