### PR TITLE
🎨 Palette: Add keyboard focus and ARIA pressed states to music controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,8 @@
 
 **Learning:** For custom toggle buttons or selectable elements acting as a group (like language selection) that use standard HTML `<button>` tags, `aria-pressed={boolean}` should be applied to convey the active state to assistive technology. Furthermore, when decorative emojis are used alongside text labels, wrapping the emoji in a `<span>` with `aria-hidden="true"` prevents redundant or confusing screen reader announcements.
 **Action:** Always apply `aria-pressed` to custom toggle buttons and add `aria-hidden="true"` to wrapper spans around decorative emojis.
+
+## 2026-07-14 - Restore focus visibility for custom themed elements
+
+**Learning:** When using custom styling that removes native focus outlines (e.g. `pixel-btn` or custom buttons), the element loses visual indications when navigated by keyboard.
+**Action:** Always restore keyboard accessibility on custom interactive elements by adding standard `focus-visible:` utility classes like `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2`.

--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -175,7 +175,8 @@ export function MusicButton() {
   return (
     <button
       onClick={toggleMusic}
-      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5"
+      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+      aria-pressed={isPlaying}
       aria-label={labelText}
       title={labelText}
     >
@@ -197,16 +198,26 @@ export function MusicVolumeSlider() {
       <div className="flex items-center justify-between">
         <button
           onClick={() => setIsPlaying(!isPlaying)}
-          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+          aria-pressed={isPlaying}
+          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none ${
             isPlaying ? "bg-[#22C55E] text-white" : "bg-gray-200 text-gray-600"
           }`}
         >
-          {isPlaying ? "🔊 On" : "🔇 Off"}
+          {isPlaying ? (
+            <>
+              <span aria-hidden="true">🔊</span> On
+            </>
+          ) : (
+            <>
+              <span aria-hidden="true">🔇</span> Off
+            </>
+          )}
         </button>
         <span className="text-sm text-[#5D4037]">{Math.round(volume * 100)}%</span>
       </div>
       <input
         type="range"
+        aria-label="Volume"
         min="0"
         max="100"
         value={volume * 100}


### PR DESCRIPTION
💡 What:
- Added `aria-pressed` attributes to the toggle buttons in `MusicButton` and `MusicVolumeSlider` to properly communicate their on/off state to assistive technologies.
- Restored keyboard accessibility by adding `focus-visible:` utility classes to both toggle buttons.
- Wrapped the decorative emojis ("🔊" and "🔇") in `<span aria-hidden="true">` in the volume slider to prevent redundant screen reader announcements.
- Added an `aria-label="Volume"` to the `<input type="range">` in the volume slider.
- Recorded a learning in `.Jules/palette.md` regarding keyboard accessibility on custom-styled elements.

🎯 Why:
To ensure the kids app settings and music controls are fully accessible to screen reader users and those navigating via keyboard.

📸 Before/After:
*Before:* Keyboard focus was invisible on the toggle buttons due to custom styling, and screen readers did not correctly announce their active state or the purpose of the volume slider.
*After:* The buttons now show a clear focus ring when navigated via keyboard. Screen readers will now announce "pressed" states appropriately, skip redundant emoji descriptions, and identify the range input as "Volume".

♿ Accessibility:
- Added `aria-pressed` for state management.
- Improved visual focus indicators (`focus-visible:ring-2`, `focus-visible:ring-offset-2`).
- Removed redundant visual cues from screen reader flows (`aria-hidden="true"` on emojis).
- Added explicit labeling for range input (`aria-label`).

---
*PR created automatically by Jules for task [8298766276209503156](https://jules.google.com/task/8298766276209503156) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves accessibility of the kids app music controls by restoring keyboard focus styles and adding pressed state semantics. Screen readers now announce toggle state correctly, the volume slider is labeled, and decorative emojis are ignored.

- **Bug Fixes**
  - Added `aria-pressed` to `MusicButton` and the volume toggle in `MusicVolumeSlider`.
  - Added `focus-visible` utilities to both buttons; documented the pattern in `.Jules/palette.md`.
  - Wrapped 🔊/🔇 in `<span aria-hidden="true">` to prevent redundant announcements.
  - Added `aria-label="Volume"` to the range input.

<sup>Written for commit f8bde35c15948532014a43976b20e974ba9b909d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

