### PR TITLE
🎨 Palette: Improve background music button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,8 @@
 
 **Learning:** For custom toggle buttons or selectable elements acting as a group (like language selection) that use standard HTML `<button>` tags, `aria-pressed={boolean}` should be applied to convey the active state to assistive technology. Furthermore, when decorative emojis are used alongside text labels, wrapping the emoji in a `<span>` with `aria-hidden="true"` prevents redundant or confusing screen reader announcements.
 **Action:** Always apply `aria-pressed` to custom toggle buttons and add `aria-hidden="true"` to wrapper spans around decorative emojis.
+
+## 2024-07-15 - Improve background music button accessibility
+
+**Learning:** When using custom UI like pixel buttons or rounded toggle buttons for background music, screen readers need `aria-pressed={boolean}` to understand the active state, and keyboard users need explicit `focus-visible` styling when default outlines are stripped. Decorative emojis (like 🔊/🔇) inside these buttons must be wrapped in `<span aria-hidden="true">` to prevent repetitive screen reader announcements.
+**Action:** Always add `aria-pressed`, explicit `focus-visible` classes, and `aria-hidden` spans on emojis for custom toggle buttons to ensure full accessibility.

--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -175,7 +175,8 @@ export function MusicButton() {
   return (
     <button
       onClick={toggleMusic}
-      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5"
+      aria-pressed={isPlaying}
+      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
       aria-label={labelText}
       title={labelText}
     >
@@ -197,11 +198,20 @@ export function MusicVolumeSlider() {
       <div className="flex items-center justify-between">
         <button
           onClick={() => setIsPlaying(!isPlaying)}
-          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+          aria-pressed={isPlaying}
+          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none ${
             isPlaying ? "bg-[#22C55E] text-white" : "bg-gray-200 text-gray-600"
           }`}
         >
-          {isPlaying ? "🔊 On" : "🔇 Off"}
+          {isPlaying ? (
+            <>
+              <span aria-hidden="true">🔊</span> On
+            </>
+          ) : (
+            <>
+              <span aria-hidden="true">🔇</span> Off
+            </>
+          )}
         </button>
         <span className="text-sm text-[#5D4037]">{Math.round(volume * 100)}%</span>
       </div>


### PR DESCRIPTION
💡 What: Added `aria-pressed`, explicit `focus-visible` states, and `aria-hidden` wrappers for emojis on background music toggle buttons.
🎯 Why: To ensure screen readers accurately read out active/inactive states for the custom toggle buttons instead of redundantly announcing emojis, and to provide visible indicators for keyboard navigation.
📸 Before/After: Added styling and HTML attributes, visually identical unless using keyboard focus (where a brown ring now appears).
♿ Accessibility: Fully accessible custom toggles via ARIA attributes and focus-visible utilities.

---
*PR created automatically by Jules for task [14160607016267089425](https://jules.google.com/task/14160607016267089425) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves accessibility of background music controls by announcing pressed state and showing a visible focus ring. Screen readers no longer read decorative emojis; keyboard users get clear focus feedback.

- **Bug Fixes**
  - Added `aria-pressed` to music toggle buttons.
  - Added `focus-visible` ring styles to custom buttons.
  - Wrapped 🔊/🔇 emojis in `<span aria-hidden="true">` to prevent duplicate announcements.

<sup>Written for commit ae320e0aee5e3a629ff07f25e69398219dd99a76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

