### PR TITLE
🎨 Palette: Add accessibility to music toggle button

### DIFF
--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -197,11 +197,20 @@ export function MusicVolumeSlider() {
       <div className="flex items-center justify-between">
         <button
           onClick={() => setIsPlaying(!isPlaying)}
-          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+          aria-pressed={isPlaying}
+          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none ${
             isPlaying ? "bg-[#22C55E] text-white" : "bg-gray-200 text-gray-600"
           }`}
         >
-          {isPlaying ? "🔊 On" : "🔇 Off"}
+          {isPlaying ? (
+            <>
+              <span aria-hidden="true">🔊</span> On
+            </>
+          ) : (
+            <>
+              <span aria-hidden="true">🔇</span> Off
+            </>
+          )}
         </button>
         <span className="text-sm text-[#5D4037]">{Math.round(volume * 100)}%</span>
       </div>


### PR DESCRIPTION
💡 What: Added `aria-pressed`, proper focus styling, and decorative emoji hiding to the `MusicVolumeSlider` component.
🎯 Why: To ensure screen readers announce the toggle state accurately and prevent redundant announcements of emojis, while also giving keyboard users a clear focus indicator.
📸 Before/After: Visuals remain unchanged, but screen reader and keyboard experience is significantly improved.
♿ Accessibility: 
- Added `aria-pressed={isPlaying}`
- Added `focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-offset-2`
- Wrapped 🔊 and 🔇 in `<span aria-hidden="true">`

---
*PR created automatically by Jules for task [2394606096731338350](https://jules.google.com/task/2394606096731338350) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `aria-pressed` and focus-visible styles to the music toggle in `MusicVolumeSlider` so screen readers announce its state and keyboard users get a clear focus ring. Also hide the 🔊/🔇 emojis from assistive tech by wrapping them in `<span aria-hidden="true">`.

<sup>Written for commit 1d6dfd8c76c806574539af180ddcdd74ec0e3232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

