### PR TITLE
🎨 Palette: [UX improvement] Add keyboard accessibility focus states to Sidebar navigation

### DIFF
--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -60,13 +60,13 @@ export function Sidebar() {
               href={item.href}
               aria-label={item.label}
               className={cn(
-                "group relative flex items-center justify-center rounded-md p-3 transition-all duration-300",
+                "group focus-visible:ring-agent-cyan relative flex items-center justify-center rounded-md p-3 transition-all duration-300 focus-visible:ring-2 focus-visible:outline-none",
                 isActive
                   ? "bg-white/10 text-white shadow-[0_0_15px_rgba(255,255,255,0.1)]"
                   : "text-white/40 hover:bg-white/5 hover:text-white"
               )}
             >
-              <item.icon size={20} />
+              <item.icon size={20} aria-hidden="true" />
               {/* Tooltip on Hover */}
               <span className="pointer-events-none absolute left-14 z-50 rounded border border-white/10 bg-black/80 px-2 py-1 text-xs whitespace-nowrap opacity-0 backdrop-blur-md transition-opacity group-hover:opacity-100">
                 {item.label}
@@ -80,10 +80,10 @@ export function Sidebar() {
       <div className="mt-auto flex w-full flex-col items-center gap-3 px-4">
         <button
           onClick={toggleLanguage}
-          className="group relative mb-2 rounded-md p-3 text-white/40 transition-all hover:bg-white/5 hover:text-white"
+          className="group focus-visible:ring-agent-cyan relative mb-2 rounded-md p-3 text-white/40 transition-all hover:bg-white/5 hover:text-white focus-visible:ring-2 focus-visible:outline-none"
           aria-label="Toggle Language"
         >
-          <Globe size={20} />
+          <Globe size={20} aria-hidden="true" />
           <span className="pointer-events-none absolute left-14 z-50 rounded border border-white/10 bg-black/80 px-2 py-1 font-mono text-[10px] whitespace-nowrap uppercase opacity-0 backdrop-blur-md transition-opacity group-hover:opacity-100">
             Toggle EN/TH
           </span>


### PR DESCRIPTION
💡 What: Added keyboard accessibility focus states (`focus-visible:ring-agent-cyan focus-visible:ring-2 focus-visible:outline-none`) to the navigation `Link` elements and the Language Toggle `button` in the `Sidebar` component. Also added `aria-hidden="true"` to the decorative inner icons.
🎯 Why: To improve the user experience for users who navigate the interface using a keyboard, ensuring they have clear visual indicators of their focused element. This aligns with accessibility best practices.
📸 Before/After: Before, keyboard focus states were not visible or clearly identifiable on sidebar items. Now, focused items highlight elegantly.
♿ Accessibility: Ensures that keyboard users can see their focus state without applying persistent focus outlines for mouse users. `aria-hidden="true"` prevents screen readers from redundantly announcing the inner decorative icons (since their parent container already uses `aria-label`).

---
*PR created automatically by Jules for task [17707875998904762141](https://jules.google.com/task/17707875998904762141) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add keyboard-visible focus rings to Sidebar navigation links and the Language Toggle button to improve focus clarity for keyboard users. Mark decorative inner icons as `aria-hidden` to prevent duplicate screen reader announcements.

<sup>Written for commit af1bc72bf3ae7efd16955f0c4ba88d5f92f4babe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

