### PR TITLE
🎨 Palette: Add accessibility attributes to layout buttons

### DIFF
--- a/src/components/layout/cli-command.tsx
+++ b/src/components/layout/cli-command.tsx
@@ -51,12 +51,14 @@ export function CliCommand() {
         {tCommon("copied")}
       </span>
       <button
+        type="button"
+        aria-label={tCommon("copy")}
         onClick={handleCopy}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
         className="group inline-flex cursor-pointer items-center gap-3 rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2.5 transition-all duration-300 hover:bg-zinc-800 dark:border-zinc-600 dark:bg-zinc-800 dark:hover:bg-zinc-700"
       >
-        <Terminal className="h-4 w-4 shrink-0 text-green-400" />
+        <Terminal className="h-4 w-4 shrink-0 text-green-400" aria-hidden="true" />
         <div className="relative flex h-5 items-center overflow-hidden">
           {/* Grid container for smooth width animation */}
           <div

--- a/src/components/layout/notification-bell.tsx
+++ b/src/components/layout/notification-bell.tsx
@@ -128,6 +128,8 @@ export function NotificationBell() {
           <span>{t("title")}</span>
           {totalCount > 0 && (
             <button
+              type="button"
+              aria-label={t("markAllRead")}
               onClick={() => handleMarkAsRead()}
               className="text-muted-foreground hover:text-foreground text-xs"
             >


### PR DESCRIPTION
💡 What: 
- Added `type="button"` and `aria-label={t("markAllRead")}` to the "Mark all as read" button in `notification-bell.tsx`.
- Added `type="button"` and `aria-label={tCommon("copy")}` to the copy CLI command button in `cli-command.tsx`.
- Added `aria-hidden="true"` to the decorative `Terminal` icon in `cli-command.tsx`.

🎯 Why: 
Buttons without explicit types can sometimes trigger unwanted form submissions if nested within a form context. Additionally, icon-only buttons or interactive elements require clear `aria-label`s for screen reader users to understand their purpose, while decorative icons should be explicitly hidden from screen readers.

📸 Before/After: 
N/A - Purely structural/accessibility changes.

♿ Accessibility: 
- Screen readers will now correctly announce "Mark all as read" and "Copy".
- Decorative icons are properly hidden from assistive technologies.

---
*PR created automatically by Jules for task [13508517515729678888](https://jules.google.com/task/13508517515729678888) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `type="button"` on layout buttons and added `aria-label`s to improve screen reader support and prevent accidental form submissions. Applies to the notification bell’s “Mark all as read” and the CLI copy button; the decorative `Terminal` icon is `aria-hidden`.

<sup>Written for commit 991fd8b755a009a2d04f03da6aecf0cfe51f4967. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

