### PR TITLE
🎨 Palette: Add accessibility attributes to music toggle button

### DIFF
--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -197,11 +197,20 @@ export function MusicVolumeSlider() {
       <div className="flex items-center justify-between">
         <button
           onClick={() => setIsPlaying(!isPlaying)}
-          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+          aria-pressed={isPlaying}
+          className={`focus-visible:ring-agent-cyan rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none ${
             isPlaying ? "bg-[#22C55E] text-white" : "bg-gray-200 text-gray-600"
           }`}
         >
-          {isPlaying ? "🔊 On" : "🔇 Off"}
+          {isPlaying ? (
+            <>
+              <span aria-hidden="true">🔊</span> On
+            </>
+          ) : (
+            <>
+              <span aria-hidden="true">🔇</span> Off
+            </>
+          )}
         </button>
         <span className="text-sm text-[#5D4037]">{Math.round(volume * 100)}%</span>
       </div>


### PR DESCRIPTION
💡 **What**: Added `aria-pressed` state, hid decorative emojis from screen readers, and improved keyboard focus visibility on the music volume toggle button.
🎯 **Why**: To provide clear active state context to screen reader users and ensure keyboard users can easily identify when the button has focus.
♿ **Accessibility**:
- Added `aria-pressed` for screen reader toggle state.
- Wrapped decorative emojis in `<span aria-hidden="true">`.
- Added `focus-visible` styles to ensure keyboard navigation is visible without outlining for mouse users.

---
*PR created automatically by Jules for task [10951570748817525705](https://jules.google.com/task/10951570748817525705) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the background music volume toggle for accessibility by adding `aria-pressed`, hiding decorative emojis from screen readers, and showing a clear keyboard focus ring. This clarifies the active state for screen reader users and makes keyboard navigation more visible without affecting mouse users.

<sup>Written for commit a493662e7952049bbcf77c8c80d2c2b90d44d625. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

