### PR TITLE
🎨 Palette: Enhance accessibility of background music toggles

### DIFF
--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -175,7 +175,8 @@ export function MusicButton() {
   return (
     <button
       onClick={toggleMusic}
-      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5"
+      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+      aria-pressed={isPlaying}
       aria-label={labelText}
       title={labelText}
     >
@@ -197,11 +198,20 @@ export function MusicVolumeSlider() {
       <div className="flex items-center justify-between">
         <button
           onClick={() => setIsPlaying(!isPlaying)}
-          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+          aria-pressed={isPlaying}
+          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none ${
             isPlaying ? "bg-[#22C55E] text-white" : "bg-gray-200 text-gray-600"
           }`}
         >
-          {isPlaying ? "🔊 On" : "🔇 Off"}
+          {isPlaying ? (
+            <>
+              <span aria-hidden="true">🔊</span> On
+            </>
+          ) : (
+            <>
+              <span aria-hidden="true">🔇</span> Off
+            </>
+          )}
         </button>
         <span className="text-sm text-[#5D4037]">{Math.round(volume * 100)}%</span>
       </div>


### PR DESCRIPTION
💡 What: 
Added `aria-pressed={isPlaying}` and keyboard `focus-visible` states to the `<MusicButton>` and `<MusicVolumeSlider>` toggles in `src/components/kids/layout/background-music.tsx`. Also wrapped the decorative volume emojis in `<span aria-hidden="true">` to prevent screen reader redundancy.

🎯 Why: 
Music buttons were lacking active state indication (`aria-pressed`) for screen readers, meaning assistive technologies wouldn't announce whether the button was currently toggled on or off. They were also missing explicit keyboard focus styles for keyboard users. The decorative emojis within the volume text would be read aloud redundantly by screen readers. 

♿ Accessibility: 
- Adds `aria-pressed` for clear toggle state announcements.
- Ensures focus rings are visible on keyboard navigation without affecting mouse users (`focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-offset-2`).
- Prevents redundant announcement of decorative emojis using `aria-hidden="true"`.

---
*PR created automatically by Jules for task [1888140958068817616](https://jules.google.com/task/1888140958068817616) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve accessibility of the background music controls by adding aria-pressed to MusicButton and MusicVolumeSlider, adding focus-visible ring styles, and hiding decorative volume emojis from screen readers. Screen readers now announce on/off correctly, and keyboard users get clear focus indicators.

<sup>Written for commit db885e1391b23ba0824ec6ebca4fbf54f06e62cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

