### PR TITLE
⚡ Bolt: Optimize CSV import to prevent N+1 query bottleneck

### DIFF
--- a/src/app/api/admin/import-prompts/route.ts
+++ b/src/app/api/admin/import-prompts/route.ts
@@ -196,17 +196,24 @@ export async function POST(request: NextRequest) {
     let skipped = 0;
     const errors: string[] = [];
 
+    // ⚡ Bolt Optimization: Prevent N+1 query by fetching existing titles in bulk
+    const titlesToImport = rows.map((r) => r.act).filter(Boolean);
+    const existingPrompts = await db.prompt.findMany({
+      where: { title: { in: titlesToImport } },
+      select: { title: true },
+    });
+    const existingTitles = new Set(existingPrompts.map((p) => p.title));
+
     for (const row of rows) {
       try {
-        // Check if prompt with same title already exists
-        const existing = await db.prompt.findFirst({
-          where: { title: row.act },
-        });
-
-        if (existing) {
+        // Check if prompt with same title already exists (O(1) memory lookup)
+        if (existingTitles.has(row.act)) {
           skipped++;
           continue;
         }
+
+        // Add to set to prevent duplicates if CSV has duplicate titles
+        existingTitles.add(row.act);
 
         // Get or create contributor user
         const authorId = await getOrCreateContributor(row.contributor);


### PR DESCRIPTION
💡 What
Replaced the `findFirst` database query inside the CSV row loop with a bulk fetch (`findMany`) of existing prompt titles using the `in` operator. The existing titles are then stored in a `Set` for O(1) lookups within the loop.

🎯 Why
When an admin uploads a CSV of prompts, the system was performing a separate database query for every single row to check for existing prompts with the same title. This created an N+1 query bottleneck that severely degraded performance and increased database load for large CSV files.

📊 Impact
Reduces database queries during the existence-check phase from O(N) to O(1) bulk query, significantly speeding up the CSV import process and reducing database overhead.

🔬 Measurement
Upload a large CSV file with hundreds of rows in the admin panel and monitor the time taken to process the import, as well as the database query logs. The number of queries should be drastically reduced.

---
*PR created automatically by Jules for task [1832030483130300851](https://jules.google.com/task/1832030483130300851) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized the admin CSV prompt import by replacing per-row existence checks with one bulk fetch and in-memory lookups. Removes the N+1 query and speeds up large imports while reducing DB load.

- **Refactors**
  - Pre-fetch existing prompt titles via `findMany` with `in`, store in a `Set` for O(1) checks.
  - Add new titles to the `Set` during processing to skip CSV duplicates.

<sup>Written for commit dc21805077103e6f8cfdab020f418a643114faeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

