### PR TITLE
🎨 Palette: Add accessibility improvements to background music buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,8 @@
 
 **Learning:** For custom toggle buttons or selectable elements acting as a group (like language selection) that use standard HTML `<button>` tags, `aria-pressed={boolean}` should be applied to convey the active state to assistive technology. Furthermore, when decorative emojis are used alongside text labels, wrapping the emoji in a `<span>` with `aria-hidden="true"` prevents redundant or confusing screen reader announcements.
 **Action:** Always apply `aria-pressed` to custom toggle buttons and add `aria-hidden="true"` to wrapper spans around decorative emojis.
+
+## 2026-07-24 - Restore keyboard accessibility to custom buttons
+
+**Learning:** When styling custom interactive UI elements that remove native browser focus outlines (e.g., pixel-btn components or custom toggles), keyboard accessibility is lost for tab-navigation users.
+**Action:** Always restore keyboard accessibility by adding explicit focus-visible: utility classes (like focus-visible:ring-agent-cyan focus-visible:ring-2 focus-visible:outline-none) to custom buttons. This ensures keyboard users can see their focus state without applying persistent focus outlines for mouse users.

--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -175,9 +175,10 @@ export function MusicButton() {
   return (
     <button
       onClick={toggleMusic}
-      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5"
+      className="pixel-btn pixel-btn-amber focus-visible:ring-agent-cyan flex h-8 items-center px-2 py-1.5 focus-visible:ring-2 focus-visible:outline-none"
       aria-label={labelText}
       title={labelText}
+      aria-pressed={isPlaying}
     >
       {isPlaying ? <PixelSpeakerOn aria-hidden="true" /> : <PixelSpeakerOff aria-hidden="true" />}
     </button>
@@ -197,11 +198,20 @@ export function MusicVolumeSlider() {
       <div className="flex items-center justify-between">
         <button
           onClick={() => setIsPlaying(!isPlaying)}
-          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+          aria-pressed={isPlaying}
+          className={`focus-visible:ring-agent-cyan rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none ${
             isPlaying ? "bg-[#22C55E] text-white" : "bg-gray-200 text-gray-600"
           }`}
         >
-          {isPlaying ? "🔊 On" : "🔇 Off"}
+          {isPlaying ? (
+            <>
+              <span aria-hidden="true">🔊</span> On
+            </>
+          ) : (
+            <>
+              <span aria-hidden="true">🔇</span> Off
+            </>
+          )}
         </button>
         <span className="text-sm text-[#5D4037]">{Math.round(volume * 100)}%</span>
       </div>


### PR DESCRIPTION
💡 What: Added aria-pressed attributes and focus-visible keyboard navigation styles to the background music toggle buttons and volume slider.
🎯 Why: Ensuring custom UI toggle elements are accessible via screen readers and visible to keyboard navigators.
♿ Accessibility:
- Added `aria-pressed={isPlaying}` to dynamically indicate active state for custom `<button>` elements.
- Wrapped decorative volume emojis in `<span aria-hidden="true">` to prevent redundant screen reader announcements.
- Restored `focus-visible` outline styles for keyboard navigation in custom buttons that strip native outlines.

---
*PR created automatically by Jules for task [12481146489582684645](https://jules.google.com/task/12481146489582684645) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make background music controls accessible for screen reader and keyboard users. Adds `aria-pressed` to toggle buttons, restores `focus-visible` styles, and hides decorative emojis with `aria-hidden`.

<sup>Written for commit 44078dbfaa3bb430be5edd44e5382dde6d16ea3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

