### PR TITLE
🎨 Palette: Improve accessibility of Copy button

### DIFF
--- a/src/components/prompts/copy-button.tsx
+++ b/src/components/prompts/copy-button.tsx
@@ -29,8 +29,18 @@ export function CopyButton({ content, promptId }: CopyButtonProps) {
   };
 
   return (
-    <Button variant="ghost" size="sm" onClick={copyToClipboard}>
-      {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={copyToClipboard}
+      aria-label={copied ? t("copied") : t("copy")}
+      title={copied ? t("copied") : t("copy")}
+    >
+      {copied ? (
+        <Check className="h-4 w-4 text-green-500" aria-hidden="true" />
+      ) : (
+        <Copy className="h-4 w-4" aria-hidden="true" />
+      )}
     </Button>
   );
 }


### PR DESCRIPTION
💡 **What:** Added `aria-label`, `title`, and `aria-hidden="true"` attributes to the icon-only `CopyButton` component.
🎯 **Why:** To provide an accessible name for screen readers, display a native tooltip on hover, and prevent screen readers from announcing decorative SVG icons, improving the overall accessibility and user experience of copying prompts.
📸 **Before/After:** No visual changes for non-assistive tech users, except for a native browser tooltip appearing on hover.
♿ **Accessibility:** Fixes a warning about missing accessible names on icon-only buttons and prevents redundant announcements of decorative icons.

---
*PR created automatically by Jules for task [6229443975324260280](https://jules.google.com/task/6229443975324260280) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved accessibility of the icon-only Copy button by adding `aria-label` and `title` for a readable name and tooltip, and marking the SVG icons as `aria-hidden` so screen readers ignore them. The label switches between “Copy” and “Copied” based on state; visuals are unchanged.

<sup>Written for commit 5d6efaf9bb75930c81e7ed0be104208f4a7d0f00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

