### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon-only buttons in developer tools

### DIFF
--- a/src/components/developers/prompt-enhancer.tsx
+++ b/src/components/developers/prompt-enhancer.tsx
@@ -72,6 +72,7 @@ function saveHistory(history: SavedPrompt[]) {
 
 export function PromptEnhancer() {
   const t = useTranslations("developers");
+  const tCommon = useTranslations("common");
   const { theme } = useTheme();
   const [prompt, setPrompt] = useState("");
   const [outputType, setOutputType] = useState<OutputType>("text");
@@ -211,8 +212,9 @@ export function PromptEnhancer() {
                       e.stopPropagation();
                       deleteFromHistory(item.id);
                     }}
+                    aria-label={tCommon("delete")}
                   >
-                    <Trash2 className="h-3 w-3" />
+                    <Trash2 aria-hidden="true" className="h-3 w-3" />
                   </Button>
                 </div>
               ))
@@ -303,8 +305,18 @@ export function PromptEnhancer() {
           {result && (
             <div className="flex items-center gap-2">
               <span className="text-muted-foreground text-xs">{result.model}</span>
-              <Button variant="ghost" size="icon" onClick={handleCopy} className="h-6 w-6">
-                {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleCopy}
+                className="h-6 w-6"
+                aria-label={tCommon("copy")}
+              >
+                {copied ? (
+                  <Check aria-hidden="true" className="h-3 w-3" />
+                ) : (
+                  <Copy aria-hidden="true" className="h-3 w-3" />
+                )}
               </Button>
               <RunPromptButton
                 content={result.improved}

--- a/src/components/developers/prompt-tokenizer.tsx
+++ b/src/components/developers/prompt-tokenizer.tsx
@@ -184,6 +184,7 @@ function tokenizeForVisualization(text: string): { start: number; end: number }[
 
 export function PromptTokenizer() {
   const t = useTranslations("developers");
+  const tCommon = useTranslations("common");
   const { theme } = useTheme();
   const [text, setText] = useState("");
   const [history, setHistory] = useState<SavedAnalysis[]>([]);
@@ -389,8 +390,9 @@ Estimated Output Cost: ${formatPrice(estimatedOutputCost)}`;
                       e.stopPropagation();
                       deleteFromHistory(item.id);
                     }}
+                    aria-label={tCommon("delete")}
                   >
-                    <Trash2 className="h-3 w-3" />
+                    <Trash2 aria-hidden="true" className="h-3 w-3" />
                   </Button>
                 </div>
               ))
@@ -421,8 +423,14 @@ Estimated Output Cost: ${formatPrice(estimatedOutputCost)}`;
                 className="scale-75"
               />
             </div>
-            <Button variant="ghost" size="icon" className="h-7 w-7" onClick={clearText}>
-              <Trash2 className="h-3.5 w-3.5" />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={clearText}
+              aria-label={tCommon("reset")}
+            >
+              <Trash2 aria-hidden="true" className="h-3.5 w-3.5" />
             </Button>
           </div>
         </div>
@@ -472,8 +480,18 @@ Estimated Output Cost: ${formatPrice(estimatedOutputCost)}`;
           <span className="text-muted-foreground text-sm font-medium">
             {t("tokenizer.analysis")}
           </span>
-          <Button variant="ghost" size="icon" onClick={handleCopy} className="h-6 w-6">
-            {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleCopy}
+            className="h-6 w-6"
+            aria-label={tCommon("copy")}
+          >
+            {copied ? (
+              <Check aria-hidden="true" className="h-3 w-3" />
+            ) : (
+              <Copy aria-hidden="true" className="h-3 w-3" />
+            )}
           </Button>
         </div>
 


### PR DESCRIPTION
💡 What: Added standard `aria-label` properties referencing localization strings to several icon-only buttons across `PromptEnhancer` and `PromptTokenizer`, and hid their inner SVG icons using `aria-hidden="true"`.
🎯 Why: Without textual context, screen readers couldn't understand what the icon-only buttons (like delete, copy, reset) were doing, creating an accessibility issue. Hiding the internal SVGs prevents redundant parsing and reading of decorative elements.
📸 Before/After: Visual presentation unchanged.
♿ Accessibility: Improved screen reader support for key interactions in developer tools.

---
*PR created automatically by Jules for task [18002627416454261583](https://jules.google.com/task/18002627416454261583) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added ARIA labels to icon-only buttons (delete, copy, reset) in PromptEnhancer and PromptTokenizer, and set inner SVGs to aria-hidden. Improves screen reader support using localized strings, with no visual changes.

<sup>Written for commit 8c9dcfd49291cc4420c84f263b66e610d2b58676. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

