### PR TITLE
🎨 Palette: [Accessibility] Improve icon-only buttons in Prompt Tokenizer

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,8 @@
 
 **Learning:** For custom toggle buttons or selectable elements acting as a group (like language selection) that use standard HTML `<button>` tags, `aria-pressed={boolean}` should be applied to convey the active state to assistive technology. Furthermore, when decorative emojis are used alongside text labels, wrapping the emoji in a `<span>` with `aria-hidden="true"` prevents redundant or confusing screen reader announcements.
 **Action:** Always apply `aria-pressed` to custom toggle buttons and add `aria-hidden="true"` to wrapper spans around decorative emojis.
+
+## 2026-07-28 - Ensure hover-only actions remain keyboard accessible
+
+**Learning:** When actions within lists or cards (like a delete button) are hidden by default and only shown on hover (`opacity-0 group-hover:opacity-100`), keyboard-only users will not see them when navigating via tab, hiding critical functionality.
+**Action:** Always append focus visibility styles (e.g., `focus-visible:opacity-100`) to elements that rely on hover state for visibility, so they appear when a keyboard user focuses on them.

--- a/src/components/developers/prompt-tokenizer.tsx
+++ b/src/components/developers/prompt-tokenizer.tsx
@@ -184,6 +184,8 @@ function tokenizeForVisualization(text: string): { start: number; end: number }[
 
 export function PromptTokenizer() {
   const t = useTranslations("developers");
+  const tCommon = useTranslations("common");
+  const tSearch = useTranslations("search");
   const { theme } = useTheme();
   const [text, setText] = useState("");
   const [history, setHistory] = useState<SavedAnalysis[]>([]);
@@ -384,13 +386,14 @@ Estimated Output Cost: ${formatPrice(estimatedOutputCost)}`;
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="absolute top-1 right-1 h-6 w-6 opacity-0 transition-opacity group-hover:opacity-100"
+                    className="absolute top-1 right-1 h-6 w-6 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
                     onClick={(e) => {
                       e.stopPropagation();
                       deleteFromHistory(item.id);
                     }}
+                    aria-label={tCommon("delete")}
                   >
-                    <Trash2 className="h-3 w-3" />
+                    <Trash2 className="h-3 w-3" aria-hidden="true" />
                   </Button>
                 </div>
               ))
@@ -421,8 +424,14 @@ Estimated Output Cost: ${formatPrice(estimatedOutputCost)}`;
                 className="scale-75"
               />
             </div>
-            <Button variant="ghost" size="icon" className="h-7 w-7" onClick={clearText}>
-              <Trash2 className="h-3.5 w-3.5" />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={clearText}
+              aria-label={tSearch("clear")}
+            >
+              <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
             </Button>
           </div>
         </div>
@@ -472,8 +481,18 @@ Estimated Output Cost: ${formatPrice(estimatedOutputCost)}`;
           <span className="text-muted-foreground text-sm font-medium">
             {t("tokenizer.analysis")}
           </span>
-          <Button variant="ghost" size="icon" onClick={handleCopy} className="h-6 w-6">
-            {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleCopy}
+            className="h-6 w-6"
+            aria-label={tCommon("copy")}
+          >
+            {copied ? (
+              <Check className="h-3 w-3" aria-hidden="true" />
+            ) : (
+              <Copy className="h-3 w-3" aria-hidden="true" />
+            )}
           </Button>
         </div>
 


### PR DESCRIPTION
💡 What: Added `aria-label` and `aria-hidden="true"` attributes to the delete, clear, and copy icon-only buttons in the Prompt Tokenizer. Also added `focus-visible:opacity-100` to the delete button to ensure it appears on keyboard focus when hidden by default.

🎯 Why: To make the prompt tokenizer interface fully accessible for screen reader and keyboard-only users, ensuring they know what each icon button does and can interact with them.

♿ Accessibility: 
- Added descriptive ARIA labels using standard translations.
- Hid decorative SVG icons from screen readers.
- Fixed keyboard accessibility for hover-dependent elements.

---
*PR created automatically by Jules for task [6346849100656857948](https://jules.google.com/task/6346849100656857948) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the Prompt Tokenizer’s icon-only buttons accessible and keyboard-friendly. Buttons now announce their purpose to screen readers, and the hover-only delete control appears on focus.

- **Bug Fixes**
  - Added `aria-label` to history delete, clear, and copy buttons using `common` and `search` translations.
  - Set `aria-hidden="true"` on decorative SVGs (`Trash2`, `Copy`, `Check`).
  - Revealed the history delete button on keyboard focus with `focus-visible:opacity-100`, and documented the pattern in `.Jules/palette.md`.

<sup>Written for commit 45a33f1af8a22efdf067dcd17bfb5f3b2d24dddf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

