### PR TITLE
🎨 Palette: Add accessibility to CopyButton

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,8 @@
 
 **Learning:** For custom toggle buttons or selectable elements acting as a group (like language selection) that use standard HTML `<button>` tags, `aria-pressed={boolean}` should be applied to convey the active state to assistive technology. Furthermore, when decorative emojis are used alongside text labels, wrapping the emoji in a `<span>` with `aria-hidden="true"` prevents redundant or confusing screen reader announcements.
 **Action:** Always apply `aria-pressed` to custom toggle buttons and add `aria-hidden="true"` to wrapper spans around decorative emojis.
+
+## 2024-11-20 - Add accessibility attributes to CopyButton
+
+**Learning:** Adding `aria-label` and changing the `size` property for buttons ensures that they are screen-reader friendly and comply with standard visual design specifications in cases where they render only an icon.
+**Action:** When working on generic interactive icons like copy controls, make sure to attach specific accessible labels to standard elements.

--- a/build_output.log
+++ b/build_output.log
@@ -1,0 +1,38 @@
+ WARN  Unsupported engine: wanted: {"node":"^24.x"} (current: {"node":"v22.22.1","pnpm":"10.30.3"})
+
+> agent-library@0.2.0 build /app
+> prisma generate --no-engine && bun exec next build
+
+Loaded Prisma config from prisma.config.ts.
+
+Prisma config detected, skipping environment variable loading.
+Prisma schema loaded from prisma/schema.prisma
+┌─────────────────────────────────────────────────────────┐
+│  Update available 6.19.2 -> 7.9.1                       │
+│                                                         │
+│  This is a major update - please follow the guide at    │
+│  https://pris.ly/d/major-version-upgrade                │
+│                                                         │
+│  Run the following to update                            │
+│    npm i --save-dev prisma@latest                       │
+│    npm i @prisma/client@latest                          │
+└─────────────────────────────────────────────────────────┘
+
+✔ Generated Prisma Client (v6.19.2, engine=none) to ./node_modules/.pnpm/@prisma+client@6.19.2_prisma@6.19.2_magicast@0.3.5_typescript@5.9.3__typescript@5.9.3/node_modules/@prisma/client in 258ms
+
+Start by importing your Prisma Client (See: https://pris.ly/d/importing-client)
+
+Tip: Interested in query caching in just a few lines of code? Try Accelerate today! https://pris.ly/tip-3-accelerate
+
+▲ Next.js 16.2.12 (Turbopack)
+- Local:         http://localhost:3000
+- Network:       http://192.168.0.2:3000
+✓ Ready in 577ms
+Attention: Next.js now collects completely anonymous telemetry regarding usage.
+This information is used to shape Next.js' roadmap and prioritize features.
+You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
+https://nextjs.org/telemetry
+
+- Experiments (use with caution):
+  · clientTraceMetadata
+  · serverActions

--- a/src/components/prompts/copy-button.tsx
+++ b/src/components/prompts/copy-button.tsx
@@ -29,8 +29,19 @@ export function CopyButton({ content, promptId }: CopyButtonProps) {
   };
 
   return (
-    <Button variant="ghost" size="sm" onClick={copyToClipboard}>
-      {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-8 w-8"
+      onClick={copyToClipboard}
+      aria-label={copied ? t("copied") : t("copy")}
+      title={copied ? t("copied") : t("copy")}
+    >
+      {copied ? (
+        <Check className="h-4 w-4 text-green-500" aria-hidden="true" />
+      ) : (
+        <Copy className="h-4 w-4" aria-hidden="true" />
+      )}
     </Button>
   );
 }


### PR DESCRIPTION
💡 What: Added `aria-label`, `title`, and `aria-hidden` attributes to the copy button and updated its `size` prop.
🎯 Why: Without these labels, screen readers will read "button" without identifying its purpose (copy). Setting icons as `aria-hidden` prevents redundant readouts.
♿ Accessibility: Ensures assistive technologies can correctly announce this icon-only button and provides visual tooltips on hover.

---
*PR created automatically by Jules for task [17974352530927724194](https://jules.google.com/task/17974352530927724194) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the icon-only `CopyButton` accessible and consistent. Adds dynamic `aria-label`/`title` (“Copy”/“Copied”), hides icons with `aria-hidden`, sets `size="icon"` with 8×8 dimensions, and updates Palette docs.

<sup>Written for commit 61c24942245b720bd7f253bb1d5f0410df6c0338. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

