### PR TITLE
🎨 Palette: [UX] Improve background music keyboard accessibility and screen reader support

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,8 @@
 
 **Learning:** For custom toggle buttons or selectable elements acting as a group (like language selection) that use standard HTML `<button>` tags, `aria-pressed={boolean}` should be applied to convey the active state to assistive technology. Furthermore, when decorative emojis are used alongside text labels, wrapping the emoji in a `<span>` with `aria-hidden="true"` prevents redundant or confusing screen reader announcements.
 **Action:** Always apply `aria-pressed` to custom toggle buttons and add `aria-hidden="true"` to wrapper spans around decorative emojis.
+
+## 2026-07-30 - Pixel Button Keyboard Accessibility
+
+**Learning:** The `pixel-btn` custom UI components in this app remove native browser focus outlines, breaking keyboard navigation visibility. The design system standardizes on `agent-cyan` for focus rings.
+**Action:** Always append `focus-visible:ring-agent-cyan focus-visible:ring-2 focus-visible:outline-none` to elements using `pixel-btn` to guarantee keyboard accessibility.

--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -175,8 +175,9 @@ export function MusicButton() {
   return (
     <button
       onClick={toggleMusic}
-      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5"
+      className="pixel-btn pixel-btn-amber focus-visible:ring-agent-cyan flex h-8 items-center px-2 py-1.5 focus-visible:ring-2 focus-visible:outline-none"
       aria-label={labelText}
+      aria-pressed={isPlaying}
       title={labelText}
     >
       {isPlaying ? <PixelSpeakerOn aria-hidden="true" /> : <PixelSpeakerOff aria-hidden="true" />}
@@ -197,11 +198,20 @@ export function MusicVolumeSlider() {
       <div className="flex items-center justify-between">
         <button
           onClick={() => setIsPlaying(!isPlaying)}
-          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+          className={`focus-visible:ring-agent-cyan rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none ${
             isPlaying ? "bg-[#22C55E] text-white" : "bg-gray-200 text-gray-600"
           }`}
+          aria-pressed={isPlaying}
         >
-          {isPlaying ? "🔊 On" : "🔇 Off"}
+          {isPlaying ? (
+            <>
+              <span aria-hidden="true">🔊</span> On
+            </>
+          ) : (
+            <>
+              <span aria-hidden="true">🔇</span> Off
+            </>
+          )}
         </button>
         <span className="text-sm text-[#5D4037]">{Math.round(volume * 100)}%</span>
       </div>


### PR DESCRIPTION
💡 What: Added `aria-pressed` states, `aria-hidden` spans on decorative emojis, and keyboard focus states (`focus-visible`) to the background music UI buttons (`MusicButton` and `MusicVolumeSlider`).
🎯 Why: Ensures screen readers announce the accurate state of the toggle buttons, prevents repetitive announcements of decorative visual icons, and enables clear visible focus for keyboard users navigating the app.
📸 Before/After: Visual focus state for `pixel-btn` instances previously absent, now rendering with a standard cyan ring upon keyboard focus.
♿ Accessibility: Addressed missing `aria-pressed`, repetitive SVG/emoji announcements, and broken keyboard focus visibility for non-standard buttons in the layout.

---
*PR created automatically by Jules for task [9467139919952579803](https://jules.google.com/task/9467139919952579803) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve keyboard accessibility and screen reader support for background music controls. Adds `aria-pressed` to `MusicButton` and the volume toggle, hides decorative emojis and speaker icons with `aria-hidden`, restores visible `focus-visible` ring styles on `pixel-btn` buttons, and documents the focus-ring standard in `.Jules/palette.md`.

<sup>Written for commit 96268ea7698fa654481b41d28816ae12dfb3ded6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

