### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Wiro Media Generator

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,9 @@
 **Vulnerability:** GitHub Actions workflows that depend on secrets (like `ADD_TO_PROJECT_PAT`) can fail with "Bad credentials" if run from forks, where secrets are not exposed to the runner.
 **Learning:** Hard failures in workflows due to missing secrets create noisy CI environments and can potentially leak the absence of specific tokens.
 **Prevention:** Always check for the existence of required secrets in the job's `if` condition (e.g., `if: secrets.ADD_TO_PROJECT_PAT != ''`) before executing steps that require them.
+
+## 2026-07-30 - [SSRF via Unvalidated Image URLs]
+
+**Vulnerability:** Server-Side Request Forgery (SSRF) risk when fetching user-provided `inputImageUrl` directly via `fetch` on the backend.
+**Learning:** Backend requests to user-controlled URLs can expose internal network services or localhost if not properly validated.
+**Prevention:** Always validate user-provided URLs to ensure they use allowed protocols (http/https) and do not target internal/private IP addresses or localhost before issuing backend requests.

--- a/src/lib/plugins/media-generators/wiro.ts
+++ b/src/lib/plugins/media-generators/wiro.ts
@@ -190,6 +190,24 @@ export const wiroGeneratorPlugin: MediaGeneratorPlugin = {
     }
 
     if (request.inputImageUrl) {
+      // Validate URL to prevent SSRF
+      try {
+        const url = new URL(request.inputImageUrl);
+        if (url.protocol !== "http:" && url.protocol !== "https:") {
+          throw new Error("Invalid URL protocol");
+        }
+        if (
+          url.hostname === "localhost" ||
+          url.hostname === "127.0.0.1" ||
+          url.hostname.startsWith("192.168.") ||
+          url.hostname.startsWith("10.")
+        ) {
+          throw new Error("Local/private IP addresses are not allowed");
+        }
+      } catch (err) {
+        throw new Error("Invalid input image URL");
+      }
+
       // Fetch the image and add it to the form
       const imageResponse = await fetch(request.inputImageUrl);
       if (imageResponse.ok) {


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Server-Side Request Forgery (SSRF) risk in the Wiro media generator when fetching a user-provided `inputImageUrl` directly without validation. This could potentially allow users to fetch internal network resources or localhost.
🎯 **Impact**: If left unpatched, attackers could potentially use this vector to probe internal systems, reach internal APIs, or access restricted services within the hosting environment.
🔧 **Fix**: Added robust URL validation using the `URL` API. It verifies that the protocol is exactly `http:` or `https:` and checks the hostname against a blocklist that includes `localhost`, `127.0.0.1`, `192.168.x.x`, and `10.x.x.x`.
✅ **Verification**: Code was formatted, linted, and tests were passed. Evaluated security journal entries against requirements.

---
*PR created automatically by Jules for task [6816371071400759824](https://jules.google.com/task/6816371071400759824) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix SSRF risk in the Wiro media generator by validating user-provided image URLs before fetching. Blocks requests to local/private hosts and non-HTTP(S) protocols to protect internal resources.

- **Bug Fixes**
  - Validate `inputImageUrl` with the `URL` API; allow only `http:` and `https:`.
  - Block `localhost`, `127.0.0.1`, and private ranges `192.168.*` and `10.*`; throw on invalid URLs.
  - Documented the vulnerability and prevention steps in `.jules/sentinel.md`.

<sup>Written for commit 1447ae9e2ed004320d1d322479673f190a2a5c5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

