### PR TITLE
🎨 Palette: Fix a11y focus visibility and ARIA labels in PromptTokenizer

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,8 @@
 
 **Learning:** For custom toggle buttons or selectable elements acting as a group (like language selection) that use standard HTML `<button>` tags, `aria-pressed={boolean}` should be applied to convey the active state to assistive technology. Furthermore, when decorative emojis are used alongside text labels, wrapping the emoji in a `<span>` with `aria-hidden="true"` prevents redundant or confusing screen reader announcements.
 **Action:** Always apply `aria-pressed` to custom toggle buttons and add `aria-hidden="true"` to wrapper spans around decorative emojis.
+
+## 2026-07-31 - Add focus visibility to hover-dependent interactive elements
+
+**Learning:** Interactive UI elements in this application frequently use hover states for visibility (e.g., `opacity-0 group-hover:opacity-100`). Without explicit focus visibility styles, these elements remain invisible when keyboard users tab to them, creating an accessibility barrier.
+**Action:** Always append focus visibility styles such as `focus-visible:opacity-100` alongside hover-dependent visibility classes to ensure keyboard accessibility.

--- a/src/components/developers/prompt-tokenizer.tsx
+++ b/src/components/developers/prompt-tokenizer.tsx
@@ -184,6 +184,7 @@ function tokenizeForVisualization(text: string): { start: number; end: number }[
 
 export function PromptTokenizer() {
   const t = useTranslations("developers");
+  const tCommon = useTranslations("common");
   const { theme } = useTheme();
   const [text, setText] = useState("");
   const [history, setHistory] = useState<SavedAnalysis[]>([]);
@@ -384,13 +385,14 @@ Estimated Output Cost: ${formatPrice(estimatedOutputCost)}`;
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="absolute top-1 right-1 h-6 w-6 opacity-0 transition-opacity group-hover:opacity-100"
+                    className="absolute top-1 right-1 h-6 w-6 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+                    aria-label={tCommon("delete")}
                     onClick={(e) => {
                       e.stopPropagation();
                       deleteFromHistory(item.id);
                     }}
                   >
-                    <Trash2 className="h-3 w-3" />
+                    <Trash2 className="h-3 w-3" aria-hidden="true" />
                   </Button>
                 </div>
               ))
@@ -421,8 +423,14 @@ Estimated Output Cost: ${formatPrice(estimatedOutputCost)}`;
                 className="scale-75"
               />
             </div>
-            <Button variant="ghost" size="icon" className="h-7 w-7" onClick={clearText}>
-              <Trash2 className="h-3.5 w-3.5" />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={clearText}
+              aria-label={tCommon("clear")}
+            >
+              <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
             </Button>
           </div>
         </div>
@@ -472,8 +480,18 @@ Estimated Output Cost: ${formatPrice(estimatedOutputCost)}`;
           <span className="text-muted-foreground text-sm font-medium">
             {t("tokenizer.analysis")}
           </span>
-          <Button variant="ghost" size="icon" onClick={handleCopy} className="h-6 w-6">
-            {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleCopy}
+            className="h-6 w-6"
+            aria-label={tCommon("copy")}
+          >
+            {copied ? (
+              <Check className="h-3 w-3" aria-hidden="true" />
+            ) : (
+              <Copy className="h-3 w-3" aria-hidden="true" />
+            )}
           </Button>
         </div>
 


### PR DESCRIPTION
### 💡 What
Added explicit `focus-visible:opacity-100` classes to hover-dependent interactive elements (e.g., the history delete button) in the `PromptTokenizer`. Additionally, added missing `aria-label` attributes to all icon-only buttons (Delete, Copy, Clear) and correctly applied `aria-hidden="true"` to their internal SVG icons. Used `useTranslations("common")` to ensure labels are properly localized.

### 🎯 Why
Interactive UI elements utilizing hover states (like `opacity-0 group-hover:opacity-100`) become completely invisible when accessed via keyboard navigation without explicit focus visibility styles. This update ensures that keyboard users can see the elements they tab to. Furthermore, icon-only buttons without explicit labels create confusion for screen reader users, while reading the internal SVG creates redundant noise.

### ♿ Accessibility
- **Keyboard Navigation:** Ensured hover-dependent delete buttons show up when receiving keyboard focus using `focus-visible:opacity-100`.
- **Screen Reader Clarity:** Added semantic ARIA labels to the Delete, Copy, and Clear icon-only buttons. Hid internal `<Check />`, `<Copy />`, and `<Trash2 />` components using `aria-hidden="true"` to stop redundant parsing.

---
*PR created automatically by Jules for task [12654828276803798944](https://jules.google.com/task/12654828276803798944) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `focus-visible:opacity-100` to hover-only controls and ARIA labels to icon-only buttons in `PromptTokenizer` to improve keyboard and screen reader accessibility. Also set SVG icons to `aria-hidden="true"`, localized labels via `useTranslations("common")`, and updated `.Jules/palette.md` with guidance on focus-visible styles for hover-dependent elements.

<sup>Written for commit f5a0e179d2561828cae35c36cdd2a12a80eb42cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

