### PR TITLE
🎨 Palette: Improve accessibility of music toggle button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,8 @@
 
 **Learning:** For custom toggle buttons or selectable elements acting as a group (like language selection) that use standard HTML `<button>` tags, `aria-pressed={boolean}` should be applied to convey the active state to assistive technology. Furthermore, when decorative emojis are used alongside text labels, wrapping the emoji in a `<span>` with `aria-hidden="true"` prevents redundant or confusing screen reader announcements.
 **Action:** Always apply `aria-pressed` to custom toggle buttons and add `aria-hidden="true"` to wrapper spans around decorative emojis.
+
+## 2026-06-15 - Improve accessibility of custom toggle button
+
+**Learning:** Improved a custom toggle button to correctly use `aria-pressed` to denote state to screen readers and also used `aria-hidden` on decorative emojis inside the button to prevent redundant screen reader announcements.
+**Action:** Add `aria-pressed` on toggle buttons and use `aria-hidden` on wrapper elements around purely decorative emojis.

--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -197,11 +197,20 @@ export function MusicVolumeSlider() {
       <div className="flex items-center justify-between">
         <button
           onClick={() => setIsPlaying(!isPlaying)}
-          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+          aria-pressed={isPlaying}
+          className={`focus-visible:ring-agent-cyan rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none ${
             isPlaying ? "bg-[#22C55E] text-white" : "bg-gray-200 text-gray-600"
           }`}
         >
-          {isPlaying ? "🔊 On" : "🔇 Off"}
+          {isPlaying ? (
+            <>
+              <span aria-hidden="true">🔊</span> On
+            </>
+          ) : (
+            <>
+              <span aria-hidden="true">🔇</span> Off
+            </>
+          )}
         </button>
         <span className="text-sm text-[#5D4037]">{Math.round(volume * 100)}%</span>
       </div>


### PR DESCRIPTION
💡 **What**: Added `aria-pressed` state and keyboard focus styles to the background music toggle button in `MusicVolumeSlider`. Also wrapped the decorative '🔊' and '🔇' emojis in `span` elements with `aria-hidden="true"`.
🎯 **Why**: To enhance accessibility for screen reader users by properly conveying the button's toggle state and preventing redundant emoji announcements, while improving keyboard navigation visibility.
♿ **Accessibility**: 
- Added `aria-pressed={isPlaying}` to correctly announce the toggle state to screen readers.
- Added `focus-visible` styles to ensure keyboard users can clearly see the focused state.
- Hid purely decorative emojis from screen readers using `aria-hidden="true"`.

---
*PR created automatically by Jules for task [9950620840602352704](https://jules.google.com/task/9950620840602352704) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves accessibility of the background music toggle by adding a pressed state, visible keyboard focus, and hiding decorative emojis from screen readers. Screen readers now announce the correct state and keyboard users get clear focus.

- **Bug Fixes**
  - Added aria-pressed={isPlaying} to the toggle button.
  - Added focus-visible ring styles for keyboard users.
  - Wrapped 🔊/🔇 in spans with aria-hidden="true" to avoid redundant announcements.

<sup>Written for commit b27c23b0c5b4f6b3233492f15ec5814cd4b204c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

