### PR TITLE
🎨 Palette: Improve accessibility of music volume toggle

### DIFF
--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -197,11 +197,20 @@ export function MusicVolumeSlider() {
       <div className="flex items-center justify-between">
         <button
           onClick={() => setIsPlaying(!isPlaying)}
-          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+          aria-pressed={isPlaying}
+          className={`focus-visible:ring-agent-cyan rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none ${
             isPlaying ? "bg-[#22C55E] text-white" : "bg-gray-200 text-gray-600"
           }`}
         >
-          {isPlaying ? "🔊 On" : "🔇 Off"}
+          {isPlaying ? (
+            <>
+              <span aria-hidden="true">🔊</span> On
+            </>
+          ) : (
+            <>
+              <span aria-hidden="true">🔇</span> Off
+            </>
+          )}
         </button>
         <span className="text-sm text-[#5D4037]">{Math.round(volume * 100)}%</span>
       </div>
@@ -209,9 +218,10 @@ export function MusicVolumeSlider() {
         type="range"
         min="0"
         max="100"
+        aria-label="Music volume"
         value={volume * 100}
         onChange={(e) => setVolume(parseInt(e.target.value) / 100)}
-        className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-[#D4A574] accent-[#8B4513]"
+        className="focus-visible:ring-agent-cyan h-2 w-full cursor-pointer appearance-none rounded-lg bg-[#D4A574] accent-[#8B4513] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
       />
     </div>
   );


### PR DESCRIPTION
This PR implements several accessibility improvements to the `MusicVolumeSlider` component in `src/components/kids/layout/background-music.tsx`:

- **Active State Announcement:** Added `aria-pressed={isPlaying}` to the `<button>` used for toggling music to properly convey its state to assistive technology.
- **Cleaner Screen Reader Experience:** Wrapped decorative emojis (🔊 and 🔇) inside `<span aria-hidden="true">` to prevent redundant or confusing screen reader announcements (e.g., "Speaker with sound waves On").
- **Keyboard Navigation Support:** Added explicit keyboard focus visibility classes (`focus-visible:ring-agent-cyan focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-offset-2`) to both the toggle button and the `<input type="range">` to ensure users relying on keyboard navigation can clearly see their focus state.
- **Accessible Slider Label:** Added an `aria-label="Music volume"` to the range `<input>` so its purpose is clear to screen readers.

---
*PR created automatically by Jules for task [9804069599722704074](https://jules.google.com/task/9804069599722704074) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved accessibility of the kids music volume toggle and slider so screen readers and keyboard users have a clearer, smoother experience. Added aria-pressed on the toggle button, an aria-label on the range input, hid decorative emojis with aria-hidden, and visible focus rings for keyboard navigation.

<sup>Written for commit e3f84b0d0a9149e97db92a9301056d2e4f8ebc71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

