### PR TITLE
🎨 Palette: Improve accessibility of Music Volume Slider toggle button

### DIFF
--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -174,6 +174,7 @@ export function MusicButton() {
 
   return (
     <button
+      aria-pressed={isPlaying}
       onClick={toggleMusic}
       className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5"
       aria-label={labelText}
@@ -196,12 +197,21 @@ export function MusicVolumeSlider() {
     <div className="space-y-2">
       <div className="flex items-center justify-between">
         <button
+          aria-pressed={isPlaying}
           onClick={() => setIsPlaying(!isPlaying)}
-          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+          className={`focus-visible:ring-agent-cyan rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none ${
             isPlaying ? "bg-[#22C55E] text-white" : "bg-gray-200 text-gray-600"
           }`}
         >
-          {isPlaying ? "🔊 On" : "🔇 Off"}
+          {isPlaying ? (
+            <>
+              <span aria-hidden="true">🔊</span> On
+            </>
+          ) : (
+            <>
+              <span aria-hidden="true">🔇</span> Off
+            </>
+          )}
         </button>
         <span className="text-sm text-[#5D4037]">{Math.round(volume * 100)}%</span>
       </div>


### PR DESCRIPTION
💡 **What**: Added `aria-pressed` attribute to the volume toggle button to indicate state, wrapped inner decorative emojis ("🔊", "🔇") in `<span aria-hidden="true">`, and added `focus-visible` styles to ensure proper keyboard navigation focus indicators.
🎯 **Why**: To enhance accessibility. Screen readers will now announce the button's toggled state properly and avoid redundantly pronouncing decorative emojis. Keyboard users will now clearly see when the element has focus.
📸 **Before/After**: Visually identical for pointer users, functionally robust for keyboard and screen reader users.
♿ **Accessibility**: Improved ARIA attributes, explicit focus rings, and suppressed decorative emoji narration.

---
*PR created automatically by Jules for task [10818951714725985092](https://jules.google.com/task/10818951714725985092) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved accessibility of the background music controls by adding `aria-pressed` to both the main music button and the volume toggle, hiding decorative emojis with `<span aria-hidden="true">`, and adding focus-visible rings for keyboard navigation. Screen readers now announce the on/off state correctly, and keyboard users see a clear focus indicator.

<sup>Written for commit 4932d48792b08ab745e4db4cfebbab94440e3eb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

