### PR TITLE
🎨 Palette: Improve accessibility of prompt enhancer buttons

### DIFF
--- a/src/components/developers/prompt-enhancer.tsx
+++ b/src/components/developers/prompt-enhancer.tsx
@@ -72,6 +72,7 @@ function saveHistory(history: SavedPrompt[]) {
 
 export function PromptEnhancer() {
   const t = useTranslations("developers");
+  const tCommon = useTranslations("common");
   const { theme } = useTheme();
   const [prompt, setPrompt] = useState("");
   const [outputType, setOutputType] = useState<OutputType>("text");
@@ -206,13 +207,14 @@ export function PromptEnhancer() {
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="absolute top-1 right-1 h-6 w-6 opacity-0 transition-opacity group-hover:opacity-100"
+                    className="focus-visible:ring-agent-cyan absolute top-1 right-1 h-6 w-6 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none"
                     onClick={(e) => {
                       e.stopPropagation();
                       deleteFromHistory(item.id);
                     }}
+                    aria-label={tCommon("delete")}
                   >
-                    <Trash2 className="h-3 w-3" />
+                    <Trash2 className="h-3 w-3" aria-hidden="true" />
                   </Button>
                 </div>
               ))
@@ -303,8 +305,18 @@ export function PromptEnhancer() {
           {result && (
             <div className="flex items-center gap-2">
               <span className="text-muted-foreground text-xs">{result.model}</span>
-              <Button variant="ghost" size="icon" onClick={handleCopy} className="h-6 w-6">
-                {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleCopy}
+                className="h-6 w-6"
+                aria-label={copied ? t("copied") : t("copy")}
+              >
+                {copied ? (
+                  <Check className="h-3 w-3" aria-hidden="true" />
+                ) : (
+                  <Copy className="h-3 w-3" aria-hidden="true" />
+                )}
               </Button>
               <RunPromptButton
                 content={result.improved}


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to the icon-only "Delete" and "Copy" buttons in the prompt enhancer, and appended `focus-visible` styles to the "Delete" button which previously relied only on hover for visibility. Also added `aria-hidden="true"` to the inner icons.

🎯 Why: Icon-only buttons without `aria-label`s are not read meaningfully by screen readers. The inner decorative icons must also be explicitly hidden from screen readers. In addition, the delete button was invisible to keyboard users who navigated to it via tabbing, as it only showed up on hover.

📸 Before/After: Before, buttons were invisible to tabbing users and lacked proper ARIA. After, they function properly with screen readers and are visually clear when focused by the keyboard.

♿ Accessibility: 
- Adds `aria-label` based on translation files (`common:delete`, `developers:copy`, `developers:copied`).
- Applies `aria-hidden="true"` to `<Trash2>`, `<Copy>`, and `<Check>` icons.
- Adds `focus-visible:opacity-100 focus-visible:ring-agent-cyan focus-visible:ring-2 focus-visible:outline-none` for keyboard navigability.

---
*PR created automatically by Jules for task [11623981783521939783](https://jules.google.com/task/11623981783521939783) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves accessibility of the prompt enhancer by adding localized aria-labels to the icon-only Delete and Copy buttons and a visible focus style for Delete. Screen readers now announce these actions, and keyboard users can see and use Delete.

- **Bug Fixes**
  - Add aria-labels for Delete (`common:delete`) and Copy (`developers:copy`/`developers:copied`).
  - Hide decorative icons from screen readers with `aria-hidden="true"`.
  - Add focus-visible styles so Delete is visible and outlined when tabbed.

<sup>Written for commit 7e9c64fb950d7a9674efb4c4f54030d202e474bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

