### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF in Wiro plugin

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,9 @@
 **Vulnerability:** GitHub Actions workflows that depend on secrets (like `ADD_TO_PROJECT_PAT`) can fail with "Bad credentials" if run from forks, where secrets are not exposed to the runner.
 **Learning:** Hard failures in workflows due to missing secrets create noisy CI environments and can potentially leak the absence of specific tokens.
 **Prevention:** Always check for the existence of required secrets in the job's `if` condition (e.g., `if: secrets.ADD_TO_PROJECT_PAT != ''`) before executing steps that require them.
+
+## 2026-08-06 - [SSRF in Media Plugins]
+
+**Vulnerability:** Fetching user-provided inputImageUrl in media plugins without validating against private/internal IP ranges.
+**Learning:** Backend processes fetching media from external URLs must validate the URL to prevent SSRF.
+**Prevention:** Use validateUrl before making outbound requests based on user input.

--- a/src/lib/plugins/media-generators/wiro.ts
+++ b/src/lib/plugins/media-generators/wiro.ts
@@ -10,6 +10,7 @@
  * - WIRO_AUDIO_MODELS (comma-separated, e.g., "elevenlabs/sound-effects")
  */
 
+import { validateUrl } from "@/lib/security";
 import type {
   MediaGeneratorPlugin,
   MediaGeneratorModel,
@@ -190,6 +191,7 @@ export const wiroGeneratorPlugin: MediaGeneratorPlugin = {
     }
 
     if (request.inputImageUrl) {
+      await validateUrl(request.inputImageUrl);
       // Fetch the image and add it to the form
       const imageResponse = await fetch(request.inputImageUrl);
       if (imageResponse.ok) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The Wiro media generator plugin fetched user-provided `inputImageUrl` directly without verifying against private/internal network access, leading to an SSRF vulnerability.
🎯 Impact: An attacker could exploit this by providing an internal URL, allowing them to scan or retrieve information from internal networks that should not be publicly accessible.
🔧 Fix: Imported the `validateUrl` function from `@/lib/security` and called it with `request.inputImageUrl` before executing the `fetch()` request, throwing an error if the URL resolves to restricted IP addresses.
✅ Verification: Ran `pnpm test`, `pnpm lint`, and `pnpm format` to confirm no regressions and standard compliance.

---
*PR created automatically by Jules for task [10825419232011643482](https://jules.google.com/task/10825419232011643482) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed SSRF in the Wiro media generator by validating user-provided image URLs before fetching. Added a Sentinel note documenting this prevention for media plugins.

- **Bug Fixes**
  - Call `validateUrl` from `@/lib/security` on `request.inputImageUrl` before `fetch()`.
  - Reject URLs that resolve to restricted IP ranges.

<sup>Written for commit 7a355cea18349e94b76d3b699b6ba92484d8420f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

