### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to profile links buttons

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -507,7 +507,9 @@
     "getVerifiedButton": "Get Verified Badge",
     "verifiedBadgePrice": "$9.99/month",
     "verifiedTitle": "Verified Supporter",
-    "verifiedThankYou": "Thank you for supporting the community! Your contribution helps keep this project running."
+    "verifiedThankYou": "Thank you for supporting the community! Your contribution helps keep this project running.",
+    "moveLinkUp": "Move link up",
+    "moveLinkDown": "Move link down"
   },
   "admin": {
     "title": "Admin Dashboard",
@@ -1248,7 +1250,6 @@
     "title": "MCP API Key",
     "description": "Generate an API key to save prompts via MCP and access your private prompts.",
     "yourApiKey": "Your API Key",
-
     "keyWarning": "Keep this key secret. Anyone with this key can access your private prompts and create prompts on your behalf.",
     "noApiKey": "You haven't generated an API key yet.",
     "generate": "Generate API Key",

--- a/src/components/settings/profile-form.tsx
+++ b/src/components/settings/profile-form.tsx
@@ -375,20 +375,22 @@ export function ProfileForm({ user, showVerifiedSection = false }: ProfileFormPr
                     variant="ghost"
                     size="icon"
                     onClick={() => moveLink(index, "up")}
+                    aria-label={t("moveLinkUp")}
                     disabled={index === 0}
                     className="text-muted-foreground hover:text-foreground h-6 w-6 shrink-0 disabled:opacity-30"
                   >
-                    <ChevronUp className="h-4 w-4" />
+                    <ChevronUp className="h-4 w-4" aria-hidden="true" />
                   </Button>
                   <Button
                     type="button"
                     variant="ghost"
                     size="icon"
                     onClick={() => moveLink(index, "down")}
+                    aria-label={t("moveLinkDown")}
                     disabled={index === customLinks.length - 1}
                     className="text-muted-foreground hover:text-foreground h-6 w-6 shrink-0 disabled:opacity-30"
                   >
-                    <ChevronDown className="h-4 w-4" />
+                    <ChevronDown className="h-4 w-4" aria-hidden="true" />
                   </Button>
                 </div>
                 <Select
@@ -426,9 +428,10 @@ export function ProfileForm({ user, showVerifiedSection = false }: ProfileFormPr
                   variant="ghost"
                   size="icon"
                   onClick={() => removeLink(index)}
+                  aria-label={t("removeLink")}
                   className="text-muted-foreground hover:text-destructive shrink-0"
                 >
-                  <Trash2 className="h-4 w-4" />
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
                 </Button>
               </div>
             ))}


### PR DESCRIPTION
💡 What: Added `aria-label`s to the icon-only buttons (Move Up, Move Down, Delete) in the custom links section of the `ProfileForm`. Nested icons (`ChevronUp`, `ChevronDown`, `Trash2`) were given `aria-hidden="true"`. Also added the missing fallback translations `moveLinkUp` and `moveLinkDown` to `messages/en.json`.
🎯 Why: Icon-only buttons without accessible names cannot be interpreted by screen readers. This ensures users relying on assistive technologies can understand and interact with the profile link ordering and deletion controls. Hiding the nested decorative icons prevents redundant screen reader announcements.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Improved screen reader support by providing explicit labels for structural form actions and removing decorative noise.

---
*PR created automatically by Jules for task [5405254854639695230](https://jules.google.com/task/5405254854639695230) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added ARIA labels to the Move Up, Move Down, and Delete icon-only buttons in the `ProfileForm` custom links, and set their nested icons to `aria-hidden` to improve screen reader support. Also added `moveLinkUp` and `moveLinkDown` fallback strings in `messages/en.json`; no visual changes.

<sup>Written for commit 0f2544478d63577b9ed6277846866f2e738bcb81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

