### PR TITLE
🎨 Palette: Hide decorative emojis from screen readers in settings modal

### DIFF
--- a/src/components/kids/layout/settings-modal.tsx
+++ b/src/components/kids/layout/settings-modal.tsx
@@ -187,11 +187,17 @@ function SettingsModal({ onClose }: { onClose: () => void }) {
           <h3 className="mb-2 text-lg font-bold text-[#5D4037]">{t("progress")}</h3>
           <div className="flex gap-4 text-[#5D4037]">
             <div>
-              <span className="text-2xl font-bold text-[#FFD700]">⭐ {stars}</span>
+              <span className="text-2xl font-bold text-[#FFD700]">
+                {" "}
+                <span aria-hidden="true">⭐</span> {stars}
+              </span>
               <div className="text-xs">{t("stars")}</div>
             </div>
             <div>
-              <span className="text-2xl font-bold text-[#22C55E]">✓ {completed}</span>
+              <span className="text-2xl font-bold text-[#22C55E]">
+                {" "}
+                <span aria-hidden="true">✓</span> {completed}
+              </span>
               <div className="text-xs">{t("completed")}</div>
             </div>
           </div>


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to the decorative star (⭐) and checkmark (✓) emojis in the kids settings modal.
🎯 Why: These emojis are used purely as visual decorators for the text immediately following them ("Stars" and "Completed"). Without `aria-hidden`, screen readers redundantly announce the emojis (e.g., "White medium star, 5, stars"), creating unnecessary noise for users.
📸 Before/After: Visuals are unchanged. The screen reader experience is improved.
♿ Accessibility: Prevents screen readers from announcing decorative icons.

---
*PR created automatically by Jules for task [1914132806578878198](https://jules.google.com/task/1914132806578878198) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hid decorative emojis in the kids settings modal from screen readers by adding aria-hidden to the ⭐ and ✓ icons. Visuals are unchanged; screen readers now announce only the "Stars" and "Completed" labels and counts.

<sup>Written for commit da38bfb6b88e90008860da40ce6f21e390308146. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

