### PR TITLE
🎨 Palette: Add focus states to layout components

### DIFF
--- a/src/components/layout/context-panel.tsx
+++ b/src/components/layout/context-panel.tsx
@@ -27,7 +27,7 @@ export function ContextPanel() {
         {pinnedItems.map((item) => (
           <div
             key={item.id}
-            className="group relative rounded border border-white/5 bg-white/5 p-3 transition-all duration-300 hover:border-white/20 hover:bg-white/10"
+            className="group focus-within:ring-agent-cyan relative rounded border border-white/5 bg-white/5 p-3 transition-all duration-300 focus-within:border-white/20 focus-within:bg-white/10 focus-within:ring-2 focus-within:ring-offset-0 focus-within:outline-none hover:border-white/20 hover:bg-white/10"
           >
             <div className="text-agent-cyan/70 mb-2 flex items-center gap-2">
               {item.type === "file" ? <FileText size={12} /> : <Database size={12} />}

--- a/src/components/layout/omni-bar.tsx
+++ b/src/components/layout/omni-bar.tsx
@@ -9,7 +9,7 @@ export function OmniBar() {
   const [activeAgent, setActiveAgent] = useState("System");
 
   return (
-    <div className="glass-panel focus-within:border-agent-cyan/30 mx-auto flex w-full max-w-3xl items-center gap-2 rounded-lg p-1 transition-all duration-300 focus-within:shadow-[0_0_30px_rgba(0,229,255,0.15)]">
+    <div className="glass-panel focus-within:border-agent-cyan/30 focus-within:ring-agent-cyan mx-auto flex w-full max-w-3xl items-center gap-2 rounded-lg p-1 transition-all duration-300 focus-within:shadow-[0_0_30px_rgba(0,229,255,0.15)] focus-within:ring-1">
       {/* Agent Switcher */}
       <button
         data-testid="agent-switcher"

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -60,7 +60,7 @@ export function Sidebar() {
               href={item.href}
               aria-label={item.label}
               className={cn(
-                "group relative flex items-center justify-center rounded-md p-3 transition-all duration-300",
+                "group focus-visible:ring-agent-cyan relative flex items-center justify-center rounded-md p-3 transition-all duration-300 focus-visible:ring-2 focus-visible:outline-none",
                 isActive
                   ? "bg-white/10 text-white shadow-[0_0_15px_rgba(255,255,255,0.1)]"
                   : "text-white/40 hover:bg-white/5 hover:text-white"
@@ -68,7 +68,7 @@ export function Sidebar() {
             >
               <item.icon size={20} />
               {/* Tooltip on Hover */}
-              <span className="pointer-events-none absolute left-14 z-50 rounded border border-white/10 bg-black/80 px-2 py-1 text-xs whitespace-nowrap opacity-0 backdrop-blur-md transition-opacity group-hover:opacity-100">
+              <span className="pointer-events-none absolute left-14 z-50 rounded border border-white/10 bg-black/80 px-2 py-1 text-xs whitespace-nowrap opacity-0 backdrop-blur-md transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
                 {item.label}
               </span>
             </Link>
@@ -80,11 +80,11 @@ export function Sidebar() {
       <div className="mt-auto flex w-full flex-col items-center gap-3 px-4">
         <button
           onClick={toggleLanguage}
-          className="group relative mb-2 rounded-md p-3 text-white/40 transition-all hover:bg-white/5 hover:text-white"
+          className="group focus-visible:ring-agent-cyan relative mb-2 rounded-md p-3 text-white/40 transition-all hover:bg-white/5 hover:text-white focus-visible:ring-2 focus-visible:outline-none"
           aria-label="Toggle Language"
         >
           <Globe size={20} />
-          <span className="pointer-events-none absolute left-14 z-50 rounded border border-white/10 bg-black/80 px-2 py-1 font-mono text-[10px] whitespace-nowrap uppercase opacity-0 backdrop-blur-md transition-opacity group-hover:opacity-100">
+          <span className="pointer-events-none absolute left-14 z-50 rounded border border-white/10 bg-black/80 px-2 py-1 font-mono text-[10px] whitespace-nowrap uppercase opacity-0 backdrop-blur-md transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
             Toggle EN/TH
           </span>
         </button>
@@ -106,7 +106,7 @@ export function Sidebar() {
                   : "opacity-30"
               )}
             />
-            <span className="pointer-events-none absolute top-1/2 left-10 z-50 -translate-y-1/2 rounded border border-white/10 bg-black/80 px-2 py-1 font-mono text-[10px] whitespace-nowrap opacity-0 backdrop-blur-md transition-opacity group-hover:opacity-100">
+            <span className="pointer-events-none absolute top-1/2 left-10 z-50 -translate-y-1/2 rounded border border-white/10 bg-black/80 px-2 py-1 font-mono text-[10px] whitespace-nowrap opacity-0 backdrop-blur-md transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
               {agent.name}: {agent.status.toUpperCase()}
             </span>
           </div>


### PR DESCRIPTION
💡 What: Added missing focus states and keyboard-accessible tooltips to the primary layout components (`sidebar`, `omni-bar`, `context-panel`).
🎯 Why: To ensure keyboard users have clear visual indicators of where focus lies on the page, significantly improving navigation without relying on mouse hover states.
📸 Before/After: Not applicable (behavioral UX changes).
♿ Accessibility: Improved keyboard navigation mapping and visual feedback mapping by using `focus-visible` utility classes and ensuring tooltips appear on focus (`group-focus-visible`).

---
*PR created automatically by Jules for task [17677276129545657511](https://jules.google.com/task/17677276129545657511) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds keyboard focus states and focus-triggered tooltips to layout components to improve navigation for keyboard users. Clarifies focus without changing the existing visual design.

- **New Features**
  - Sidebar actions: `focus-visible` ring and tooltips on focus.
  - OmniBar: `focus-within` ring and subtle focus shadow.
  - ContextPanel cards: `focus-within` ring, border, and background on focus.

<sup>Written for commit 0549029aa77dc5612244f9ce5e01af9d3d7aeb15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

