### PR TITLE
🎨 Palette: [Accessibility] Improve kids music control slider

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,8 @@
 
 **Learning:** For custom toggle buttons or selectable elements acting as a group (like language selection) that use standard HTML `<button>` tags, `aria-pressed={boolean}` should be applied to convey the active state to assistive technology. Furthermore, when decorative emojis are used alongside text labels, wrapping the emoji in a `<span>` with `aria-hidden="true"` prevents redundant or confusing screen reader announcements.
 **Action:** Always apply `aria-pressed` to custom toggle buttons and add `aria-hidden="true"` to wrapper spans around decorative emojis.
+
+## 2024-08-13 - Enhance custom slider volume and music controls
+
+**Learning:** When using `<input type="range">` alongside custom toggle buttons for music controls, ensure the input has an `aria-label` (like "Volume") if a visual label isn't directly associated via `id` and `htmlFor`. Furthermore, when a button uses emojis to indicate state (🔊 On / 🔇 Off), wrap the emoji in a `<span aria-hidden="true">` to prevent assistive technology from redundantly reading the character along with the text. Add `focus-visible` states to custom range sliders to maintain keyboard accessibility, especially when the default styling might obscure standard focus outlines.
+**Action:** Consistently apply `aria-hidden` to decorative emojis and `aria-label` to custom range inputs. Ensure `focus-visible` styles are provided for custom interactive components.

--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -197,11 +197,20 @@ export function MusicVolumeSlider() {
       <div className="flex items-center justify-between">
         <button
           onClick={() => setIsPlaying(!isPlaying)}
-          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+          aria-pressed={isPlaying}
+          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:outline-none ${
             isPlaying ? "bg-[#22C55E] text-white" : "bg-gray-200 text-gray-600"
           }`}
         >
-          {isPlaying ? "🔊 On" : "🔇 Off"}
+          {isPlaying ? (
+            <>
+              <span aria-hidden="true">🔊</span> On
+            </>
+          ) : (
+            <>
+              <span aria-hidden="true">🔇</span> Off
+            </>
+          )}
         </button>
         <span className="text-sm text-[#5D4037]">{Math.round(volume * 100)}%</span>
       </div>
@@ -210,8 +219,9 @@ export function MusicVolumeSlider() {
         min="0"
         max="100"
         value={volume * 100}
+        aria-label="Volume"
         onChange={(e) => setVolume(parseInt(e.target.value) / 100)}
-        className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-[#D4A574] accent-[#8B4513]"
+        className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-[#D4A574] accent-[#8B4513] focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:outline-none"
       />
     </div>
   );


### PR DESCRIPTION
💡 **What:** Enhanced the accessibility of the `MusicVolumeSlider` component.

🎯 **Why:** 
- The toggle button previously lacked `aria-pressed`, meaning screen readers couldn't identify if the music was on or off.
- The `🔊` and `🔇` emojis were read aloud by screen readers alongside the text ("On" or "Off"), which is redundant and confusing.
- The custom range slider lacked an `aria-label`, so screen readers didn't know what it controlled.
- Both custom elements lacked standard focus outlines, making it hard for keyboard users to track their position.

📸 **Before/After:** (See the attached visual verification for UI unchangedness and focus state testing).

♿ **Accessibility:** 
- Added `aria-pressed={isPlaying}` to the play/mute button.
- Wrapped emojis in `<span aria-hidden="true">`.
- Added `aria-label="Volume"` to the `<input type="range">`.
- Added `focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:outline-none` to both the button and input.

---
*PR created automatically by Jules for task [11189337432718783623](https://jules.google.com/task/11189337432718783623) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the kids music toggle and volume slider accessible so screen reader and keyboard users can reliably control music. Previously the toggle had no state, emojis were announced, and the slider had no accessible name; now the toggle exposes aria-pressed, emojis are hidden from assistive tech, the slider is labeled “Volume,” and both controls show keyboard focus.

- Toggle: adds aria-pressed and wraps 🔊/🔇 in <span aria-hidden="true">.
- Slider: adds aria-label="Volume" and focus-visible outlines on both controls. Side effect: focus rings appear during keyboard navigation; visuals otherwise unchanged.
- Docs: records guidelines in `.Jules/palette.md`.

<sup>Written for commit 572677a79f681e04164b4c567b5e585edca954a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

