### PR TITLE
🎨 Palette: Improve accessibility for music volume slider

### DIFF
--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -197,11 +197,20 @@ export function MusicVolumeSlider() {
       <div className="flex items-center justify-between">
         <button
           onClick={() => setIsPlaying(!isPlaying)}
-          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+          aria-pressed={isPlaying}
+          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:outline-none ${
             isPlaying ? "bg-[#22C55E] text-white" : "bg-gray-200 text-gray-600"
           }`}
         >
-          {isPlaying ? "🔊 On" : "🔇 Off"}
+          {isPlaying ? (
+            <>
+              <span aria-hidden="true">🔊</span> On
+            </>
+          ) : (
+            <>
+              <span aria-hidden="true">🔇</span> Off
+            </>
+          )}
         </button>
         <span className="text-sm text-[#5D4037]">{Math.round(volume * 100)}%</span>
       </div>
@@ -210,8 +219,9 @@ export function MusicVolumeSlider() {
         min="0"
         max="100"
         value={volume * 100}
+        aria-label="Volume"
         onChange={(e) => setVolume(parseInt(e.target.value) / 100)}
-        className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-[#D4A574] accent-[#8B4513]"
+        className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-[#D4A574] accent-[#8B4513] focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:outline-none"
       />
     </div>
   );


### PR DESCRIPTION
💡 What: Added ARIA attributes and focus styles to the music volume slider and toggle button. Also hid decorative emojis from screen readers.
🎯 Why: Enhances keyboard navigation and screen reader support for the kids' volume control, making it fully accessible.
📸 Before/After: Visuals remain unchanged for mouse users, but keyboard focus states are now clearly visible.
♿ Accessibility:
- Added `aria-pressed` to the toggle button.
- Added `aria-label="Volume"` to the range input.
- Added `focus-visible` styles (`focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:outline-none`) to both interactive elements.
- Wrapped decorative 🔊 and 🔇 emojis in `<span aria-hidden="true">` to prevent redundant screen reader announcements.

---
*PR created automatically by Jules for task [17285025595189366298](https://jules.google.com/task/17285025595189366298) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the kids’ music volume controls accessible by adding ARIA and keyboard focus support and hiding decorative emojis from screen readers. Previously the toggle and slider lacked clear labels and focus indication; now the toggle exposes `aria-pressed`, the slider has `aria-label="Volume"`, both show a visible focus ring, and emojis are `aria-hidden`. Mouse visuals remain the same.

- Verify in src/components/kids/layout/background-music.tsx that the toggle updates `aria-pressed` with play state.
- Tab to the toggle and slider to see the `focus-visible` ring and check contrast against backgrounds.
- With a screen reader, confirm the slider is announced as “Volume” and the toggle announces only “On/Off” (no emoji).
- No props, APIs, or styles outside this component changed; no migration required.

<sup>Written for commit a125c50ed3a6d1c4a03584918716e8cf2cde0015. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

