### PR TITLE
🎨 Palette: Add ARIA labels and focus styles to WidgetCard copy button

### DIFF
--- a/src/components/prompts/widget-card.tsx
+++ b/src/components/prompts/widget-card.tsx
@@ -133,8 +133,8 @@ export function WidgetCard({ prompt }: WidgetCardProps) {
           )}
         </div>
         <div className="flex items-center gap-2">
-          <button onClick={copyToClipboard} className="hover:bg-accent rounded p-1">
-            <Copy className="h-3 w-3" />
+          <button onClick={copyToClipboard} className="hover:bg-accent rounded p-1 focus-visible:ring-2 focus-visible:outline-none" aria-label={tCommon("copy")}>
+            <Copy className="h-3 w-3" aria-hidden="true" />
           </button>
           {prompt.actionUrl ? (
             <Link

--- a/src/components/prompts/widget-card.tsx
+++ b/src/components/prompts/widget-card.tsx
@@ -133,7 +133,11 @@ export function WidgetCard({ prompt }: WidgetCardProps) {
           )}
         </div>
         <div className="flex items-center gap-2">
-          <button onClick={copyToClipboard} className="hover:bg-accent rounded p-1 focus-visible:ring-2 focus-visible:outline-none" aria-label={tCommon("copy")}>
+          <button
+            onClick={copyToClipboard}
+            className="hover:bg-accent rounded p-1 focus-visible:ring-2 focus-visible:outline-none"
+            aria-label={tCommon("copy")}
+          >
             <Copy className="h-3 w-3" aria-hidden="true" />
           </button>
           {prompt.actionUrl ? (


### PR DESCRIPTION
💡 What: Added `aria-label` to the icon-only "Copy" button in `WidgetCard`, added `aria-hidden="true"` to its inner `<Copy>` SVG, and added `focus-visible` utility classes.
🎯 Why: Improves screen reader accessibility by providing a label and hiding decorative icons, and ensures keyboard navigators have a visible focus indicator.
📸 Before/After: N/A (invisible to sighted mouse users, visible focus ring for keyboard users).
♿ Accessibility: Ensures compliance with WCAG guidelines for icon-only buttons and keyboard accessibility.

---
*PR created automatically by Jules for task [12888093216540625419](https://jules.google.com/task/12888093216540625419) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a localized ARIA label and keyboard-only focus styles to the `WidgetCard` copy button to improve accessibility. Previously the icon-only button had no accessible name or visible focus; now it announces as “Copy,” hides the decorative icon from assistive tech, and shows a `focus-visible` ring. Also formats `src/components/prompts/widget-card.tsx` with Prettier (no functional changes).

- Adds `aria-label={tCommon("copy")}` for the accessible name.
- Marks `<Copy>` as `aria-hidden="true"` to avoid duplicate announcements.
- Shows a focus ring on keyboard focus only.

<sup>Written for commit 1ef74b24cae74b3aff082168910f0e8644b0d910. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

