### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in Prompt Tokenizer

### DIFF
--- a/src/components/developers/prompt-tokenizer.tsx
+++ b/src/components/developers/prompt-tokenizer.tsx
@@ -184,6 +184,7 @@ function tokenizeForVisualization(text: string): { start: number; end: number }[
 
 export function PromptTokenizer() {
   const t = useTranslations("developers");
+  const tCommon = useTranslations("common");
   const { theme } = useTheme();
   const [text, setText] = useState("");
   const [history, setHistory] = useState<SavedAnalysis[]>([]);
@@ -384,13 +385,14 @@ Estimated Output Cost: ${formatPrice(estimatedOutputCost)}`;
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="absolute top-1 right-1 h-6 w-6 opacity-0 transition-opacity group-hover:opacity-100"
+                    aria-label={tCommon("delete")}
+                    className="absolute top-1 right-1 h-6 w-6 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
                     onClick={(e) => {
                       e.stopPropagation();
                       deleteFromHistory(item.id);
                     }}
                   >
-                    <Trash2 className="h-3 w-3" />
+                    <Trash2 className="h-3 w-3" aria-hidden="true" />
                   </Button>
                 </div>
               ))
@@ -421,8 +423,14 @@ Estimated Output Cost: ${formatPrice(estimatedOutputCost)}`;
                 className="scale-75"
               />
             </div>
-            <Button variant="ghost" size="icon" className="h-7 w-7" onClick={clearText}>
-              <Trash2 className="h-3.5 w-3.5" />
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={tCommon("delete")}
+              className="h-7 w-7"
+              onClick={clearText}
+            >
+              <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
             </Button>
           </div>
         </div>
@@ -472,8 +480,18 @@ Estimated Output Cost: ${formatPrice(estimatedOutputCost)}`;
           <span className="text-muted-foreground text-sm font-medium">
             {t("tokenizer.analysis")}
           </span>
-          <Button variant="ghost" size="icon" onClick={handleCopy} className="h-6 w-6">
-            {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={tCommon("copy")}
+            onClick={handleCopy}
+            className="h-6 w-6"
+          >
+            {copied ? (
+              <Check className="h-3 w-3" aria-hidden="true" />
+            ) : (
+              <Copy className="h-3 w-3" aria-hidden="true" />
+            )}
           </Button>
         </div>
 


### PR DESCRIPTION
💡 What:
Added `aria-label` attributes to the icon-only buttons (Delete, Copy, Clear text) in the `PromptTokenizer` component. Hid the decorative inner SVG icons from screen readers using `aria-hidden="true"`. Also added `focus-visible:opacity-100` to the history item delete button to ensure it is visible when navigating via keyboard.

🎯 Why:
To ensure icon-only buttons are properly announced by screen readers, preventing them from just reading "button", and to stop redundant readings of the SVG icons. Additionally, making hover-only buttons visible on keyboard focus ensures keyboard-only users can discover and interact with them.

📸 Before/After:
Before: `<Button size="icon"><Trash2 /></Button>`
After: `<Button size="icon" aria-label="Delete"><Trash2 aria-hidden="true" /></Button>`

♿ Accessibility:
- Added `aria-label` via `tCommon` translations.
- Added `aria-hidden="true"` to inner decorative SVG icons.
- Added `focus-visible:opacity-100` for keyboard focus state visibility.

---
*PR created automatically by Jules for task [3423058306970474689](https://jules.google.com/task/3423058306970474689) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ARIA labels to icon-only buttons in `PromptTokenizer`, hides decorative SVGs from screen readers, and makes the history delete button visible on keyboard focus. Previously, screen readers announced these as “button” and read the inner icons; now they announce “Delete”/“Copy,” and the delete control is discoverable via keyboard.

- Verify `tCommon("delete")` and `tCommon("copy")` exist in `common` translations; add them if missing.
- Confirm `focus-visible:opacity-100` reveals the history item delete button during keyboard navigation.
- No functional changes to handlers; only accessibility attributes and styles were updated.

<sup>Written for commit fc6313a137960c7c74803fd1e0e2c39e79c8f562. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

