### PR TITLE
🎨 Palette: Improve accessibility of background music volume slider

### DIFF
--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -197,11 +197,20 @@ export function MusicVolumeSlider() {
       <div className="flex items-center justify-between">
         <button
           onClick={() => setIsPlaying(!isPlaying)}
-          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+          aria-pressed={isPlaying}
+          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:outline-none ${
             isPlaying ? "bg-[#22C55E] text-white" : "bg-gray-200 text-gray-600"
           }`}
         >
-          {isPlaying ? "🔊 On" : "🔇 Off"}
+          {isPlaying ? (
+            <>
+              <span aria-hidden="true">🔊</span> On
+            </>
+          ) : (
+            <>
+              <span aria-hidden="true">🔇</span> Off
+            </>
+          )}
         </button>
         <span className="text-sm text-[#5D4037]">{Math.round(volume * 100)}%</span>
       </div>
@@ -209,9 +218,10 @@ export function MusicVolumeSlider() {
         type="range"
         min="0"
         max="100"
+        aria-label="Volume"
         value={volume * 100}
         onChange={(e) => setVolume(parseInt(e.target.value) / 100)}
-        className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-[#D4A574] accent-[#8B4513]"
+        className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-[#D4A574] accent-[#8B4513] focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:ring-offset-2 focus-visible:outline-none"
       />
     </div>
   );


### PR DESCRIPTION
💡 What: Added `aria-label` to the range input, `aria-pressed` to the toggle button, wrapped emojis in `aria-hidden="true"` spans, and added missing keyboard `focus-visible` rings.
🎯 Why: Improves screen reader comprehension and keyboard accessibility for visually impaired users interacting with the background music controls in the kids section settings modal.
📸 Before/After: Verified visual states locally. Unfocused state remains identical, focused state now clearly displays standard kids section (#8B4513) focus ring.
♿ Accessibility: Emojis are appropriately skipped by screen readers to avoid redundant vocalizations, the slider input is properly labeled via `aria-label`, the toggle state is announced via `aria-pressed`, and custom focus indicators restore visibility for keyboard navigators.

---
*PR created automatically by Jules for task [1700609341122022687](https://jules.google.com/task/1700609341122022687) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves accessibility of the Kids settings modal background music controls by adding ARIA semantics and keyboard focus indicators. Previously the slider lacked an accessible name and the toggle did not expose state; now the slider is labeled, emojis are hidden from assistive tech, and the toggle announces its pressed state, with visible keyboard focus rings in #8B4513.

- Toggle button: sets aria-pressed from isPlaying and adds a focus-visible ring; button text and behavior are unchanged.
- Volume slider: adds aria-label "Volume", retains 0–100 UI mapping to 0–1 state, and adds a focus-visible ring with offset; unfocused visuals are unchanged.
- Emojis: wrapped in aria-hidden spans so screen readers do not announce them.

<sup>Written for commit 5e6e5137f66d091d02bbb7ccc5cc7521da53fc3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

