### PR TITLE
🎨 Palette: Improve accessibility of volume controls

### DIFF
--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -176,7 +176,7 @@ export function MusicButton() {
     <button
       onClick={toggleMusic}
       aria-pressed={isPlaying}
-      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#8B4513]"
+      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5 focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:outline-none"
       aria-label={labelText}
       title={labelText}
     >
@@ -199,7 +199,7 @@ export function MusicVolumeSlider() {
         <button
           onClick={() => setIsPlaying(!isPlaying)}
           aria-pressed={isPlaying}
-          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#8B4513] ${
+          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:outline-none ${
             isPlaying ? "bg-[#22C55E] text-white" : "bg-gray-200 text-gray-600"
           }`}
         >
@@ -222,7 +222,7 @@ export function MusicVolumeSlider() {
         value={volume * 100}
         onChange={(e) => setVolume(parseInt(e.target.value) / 100)}
         aria-label="Volume"
-        className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-[#D4A574] accent-[#8B4513] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#8B4513]"
+        className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-[#D4A574] accent-[#8B4513] focus-visible:ring-2 focus-visible:ring-[#8B4513] focus-visible:outline-none"
       />
     </div>
   );

--- a/src/components/kids/layout/background-music.tsx
+++ b/src/components/kids/layout/background-music.tsx
@@ -175,7 +175,8 @@ export function MusicButton() {
   return (
     <button
       onClick={toggleMusic}
-      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5"
+      aria-pressed={isPlaying}
+      className="pixel-btn pixel-btn-amber flex h-8 items-center px-2 py-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#8B4513]"
       aria-label={labelText}
       title={labelText}
     >
@@ -197,11 +198,20 @@ export function MusicVolumeSlider() {
       <div className="flex items-center justify-between">
         <button
           onClick={() => setIsPlaying(!isPlaying)}
-          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+          aria-pressed={isPlaying}
+          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#8B4513] ${
             isPlaying ? "bg-[#22C55E] text-white" : "bg-gray-200 text-gray-600"
           }`}
         >
-          {isPlaying ? "🔊 On" : "🔇 Off"}
+          {isPlaying ? (
+            <>
+              <span aria-hidden="true">🔊</span> On
+            </>
+          ) : (
+            <>
+              <span aria-hidden="true">🔇</span> Off
+            </>
+          )}
         </button>
         <span className="text-sm text-[#5D4037]">{Math.round(volume * 100)}%</span>
       </div>
@@ -211,7 +221,8 @@ export function MusicVolumeSlider() {
         max="100"
         value={volume * 100}
         onChange={(e) => setVolume(parseInt(e.target.value) / 100)}
-        className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-[#D4A574] accent-[#8B4513]"
+        aria-label="Volume"
+        className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-[#D4A574] accent-[#8B4513] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#8B4513]"
       />
     </div>
   );


### PR DESCRIPTION
💡 What: Added ARIA attributes (`aria-pressed`, `aria-label`), focus states (`focus-visible`), and wrapped decorative emojis for the music volume controls.
🎯 Why: To improve screen reader experience and keyboard accessibility for the music toggle and volume slider components.
📸 Before/After: Visual focus rings added for keyboard navigation, and screen reader output fixed by hiding decorative emojis and providing clear labels.
♿ Accessibility: Applied `aria-pressed`, `aria-label`, `aria-hidden` and `focus-visible` classes to the `MusicButton` and `MusicVolumeSlider` components.

---
*PR created automatically by Jules for task [17273129332056848094](https://jules.google.com/task/17273129332056848094) started by @billlzzz10*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves keyboard and screen-reader accessibility for the background music controls. Previously, emojis were announced and toggles had no pressed state; now both toggle buttons set `aria-pressed`, the slider has an accessible name, decorative emojis are hidden, and keyboard users get visible focus rings without changing playback behavior.

- Verify `MusicButton` and the slider’s toggle update `aria-pressed` and screen readers announce “On/Off” without reading the emoji.
- Confirm the range input exposes the name “Volume” and announces percentage changes.
- Check `focus-visible` rings (brown `#8B4513`) render on both buttons and the slider; no API or design tokens changed elsewhere.

<sup>Written for commit 37c7920e1ffd84e22b6fa6ef4243cc0f675bd8ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/agent-library/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

